### PR TITLE
chore(docs): creating contribution guidelines for Typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,10 +44,53 @@ Run `make ci` before pushing any changes.
 
 ## Commit Messages
 
-- Use the imperative mood: "Fix typo correction for docker commands"
-- Keep the subject line under 72 characters
-- Separate subject from body with a blank line
-- Use the body to explain *what* and *why*, not *how*
+All commit messages must follow the format:
+
+```
+<type>(<scope>): <message>
+```
+
+Use the imperative mood in `<message>` (e.g., "add support for..." not "added support for..."). Keep the subject line under 72 characters. Separate subject from body with a blank line, and use the body to explain *what* and *why*, not *how*.
+
+### Types
+
+| Type | Purpose |
+|------|---------|
+| `feat` | New feature or user-facing functionality |
+| `fix` | Bug fix |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `test` | Adding or updating tests |
+| `chore` | Maintenance, tooling, CI, dependencies, or documentation |
+| `perf` | Performance improvement |
+| `style` | Code formatting (no logic changes) |
+| `ci` | CI/CD configuration changes |
+
+### Scopes
+
+The `<scope>` should identify the part of the codebase affected. Examples:
+
+- `cmd` -- CLI entry point and command handling
+- `engine` -- Correction engine and matching logic
+- `rules` -- Built-in or user-defined rule management
+- `history` -- Correction history
+- `install` -- Shell integration and install scripts
+- `e2e` -- End-to-end tests
+- `docs` -- README, CONTRIBUTING, or other documentation
+- `deps` -- Dependency changes
+- `build` -- Makefile and build configuration
+
+### Examples
+
+```
+feat(engine): add keyboard-aware cost for Dvorak layout
+fix(cmd): handle quoted arguments in compound commands
+refactor(rules): extract subcommand cache into separate module
+test(engine): add table-driven tests for edit distance
+chore(docs): update installation instructions for Homebrew
+chore(deps): bump mvdan.cc/sh to v3.14.0
+ci(workflows): add Go 1.26 to test matrix
+perf(engine): reduce allocations in fuzzy matching
+```
 
 ## Pull Request Expectations
 


### PR DESCRIPTION
This PR creates basis for contribution guidelines for Typo, they can be refined further but this is a good start given the current status of the project is at the early stages. 

This implements the first issue in the project #1.  