### PR TITLE
fix: parse comma-separated subcommands for npm v6-v11 help formats

### DIFF
--- a/internal/commands/subcommands.go
+++ b/internal/commands/subcommands.go
@@ -294,19 +294,40 @@ func parseDockerHelp(output string) []string {
 
 func parseNpmHelp(output string) []string {
 	// npm help format:
-	// install, i, add      Install a package
-	// run, run-script      Run arbitrary package scripts
+	// All commands:
+	// 	   access, ...
+	// 	   config, ...
+	// 	   edit, ....
 	subcommands := []string{}
-	re := regexp.MustCompile(`^\s{2,}([\w-]+)`)
-
 	scanner := bufio.NewScanner(strings.NewReader(output))
+
+	inCommandsSection := false
+
 	for scanner.Scan() {
 		line := scanner.Text()
-		if matches := re.FindStringSubmatch(line); len(matches) > 1 {
-			// Only take the first command, not aliases
-			cmd := matches[1]
-			if !strings.Contains(line, ",") || strings.Index(line, cmd) < strings.Index(line, ",") {
-				subcommands = append(subcommands, cmd)
+
+		// Compatible with with npm v7+ (All commands) and v6- (where <command> is one of:)
+		if strings.HasPrefix(line, "All commands:") || strings.Contains(line, "where <command> is one of:") {
+			inCommandsSection = true
+			continue
+		}
+		if inCommandsSection {
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			// End of commands block
+			if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+				inCommandsSection = false
+				// Don't break to prevent future versions with multiple command sections from being missed
+				continue
+			}
+			// Extract commands from the line
+			parts := strings.Split(line, ",")
+			for _, part := range parts {
+				cmd := strings.TrimSpace(part)
+				if cmd != "" {
+					subcommands = append(subcommands, cmd)
+				}
 			}
 		}
 	}

--- a/internal/commands/subcommands_test.go
+++ b/internal/commands/subcommands_test.go
@@ -718,7 +718,20 @@ func TestFetchSubcommands_Npm(t *testing.T) {
 		cacheExpiry: 7 * 24 * time.Hour,
 	}
 	result := r.fetchSubcommands("npm")
-	_ = result
+	if len(result) == 0 {
+		t.Fatalf("Expected npm subcommands")
+	}
+	// List of core commands that MUST exist in any npm version
+	expectedCmds := []string{"install", "config", "test", "publish"}
+	actualCmds := make(map[string]bool)
+	for _, cmd := range result {
+		actualCmds[cmd] = true
+	}
+	for _, expected := range expectedCmds {
+		if !actualCmds[expected] {
+			t.Errorf("Expected npm to have subcommand '%s', but it was missing", expected)
+		}
+	}
 }
 
 func TestFetchSubcommands_Go(t *testing.T) {


### PR DESCRIPTION
### Description
The current `parseNpmHelp` function relies on a regex (`^\s{2,}([\w-]+)`) that expects subcommands to be at the beginning of each line with indentation. However, actual `npm help` outputs list subcommands in comma-separated blocks.

This caused `typo` to miss the vast majority of npm subcommands (e.g., `audit`, `run`, `test`), resulting in failed auto-corrections for common npm typos.

### Changes Made
- **Refactored `parseNpmHelp`**: Replaced the regex with a robust, lightweight state machine using `strings`.
- **Compatibility**: The parser now includes a dual-trigger condition:
  - `All commands:` (Supports modern npm v7+)
  - `where <command> is one of:` (Supports legacy npm v6)
- **Added Tests**: Added `TestFetchSubcommands_Npm` to assert that core npm commands are successfully extracted, ensuring future stability.

### Motivation
Fixes the bug where `typo` could not correct most npm subcommands due to incomplete parsing of the CLI help output. The updated state machine ensures full compatibility across all major npm versions in the wild, while also improving parsing performance by removing regex overhead.