### PR TITLE
fix(subcommands): increase default help timeout to 1s to stabilize CI

### DIFF
--- a/internal/commands/subcommands.go
+++ b/internal/commands/subcommands.go
@@ -34,7 +34,7 @@ type SubcommandRegistry struct {
 	helpTimeout time.Duration
 }
 
-const defaultHelpTimeout = 500 * time.Millisecond
+const defaultHelpTimeout = 1000 * time.Millisecond
 
 // NewSubcommandRegistry creates a new subcommand registry.
 func NewSubcommandRegistry(cacheDir string) *SubcommandRegistry {


### PR DESCRIPTION
This PR increases defaultHelpTimeout from 500ms to 1s to resolve the flaky test issues identified in #13.

Fixes: #13 