### PR TITLE
refactor(install): make post-install message shell-agnostic

### DIFF
--- a/tools/scripts/install.sh
+++ b/tools/scripts/install.sh
@@ -82,6 +82,18 @@ normalize_arch() {
   esac
 }
 
+detect_shell() {
+  local shell_name
+  shell_name="$(basename "${SHELL:-}")"
+
+  case "$shell_name" in
+    zsh)  echo "zsh" ;;
+    bash) echo "bash" ;;
+    fish) echo "fish" ;;
+    *)    echo "" ;;
+  esac
+}
+
 normalize_tag() {
   local input="$1"
 
@@ -239,7 +251,17 @@ main() {
   fi
 
   install_binary "$binary_path" "$install_dir"
-  echo "Please add 'eval \"\$(typo init zsh)\"' to your shell configuration file (e.g., ~/.zshrc) to enable shell integration. Not forgotten to source it!"
+
+  # fetch shell
+  local shell
+  shell="$(detect_shell)"
+  if [[ -z "$shell" ]]; then
+    echo "Warning: Unrecognised shell '${SHELL:-}'. Add 'eval \"\$(typo init <shell>)\"' to your shell config manually." >&2
+  elif [[ "$shell" == "fish" ]]; then
+    echo "Please add 'typo init fish | source' to your shell configuration file (e.g., ~/.config/fish/config.fish) to enable shell integration. Not forgotten to source it!"
+  else
+    echo "Please add 'eval \"\$(typo init ${shell})\"' to your shell configuration file (e.g., ~/.${shell}rc) to enable shell integration. Not forgotten to source it!"
+  fi
 }
 
 main "$@"


### PR DESCRIPTION
### Summary

The install script previously hardcoded `zsh` in its post-install message, so bash and fish users were incorrectly told to configure their zsh shell. This PR detects the user's login shell at install time and shows the correct instructions for each shell.

Closes #21

### Changes

- Added `detect_shell()` function that reads `$SHELL` to detect `zsh`, `bash`, or `fish`
- Replaced the hardcoded post-install message with shell-aware output:
  - **zsh / bash**: `eval "$(typo init <shell>)"` with the correct rc file path (`~/.zshrc` or `~/.bashrc`)
  - **fish**: `typo init fish | source` with the correct config path (`~/.config/fish/config.fish`)
  - **unknown shell**: prints a warning to stderr instead of aborting, since the binary is already installed at that point

### Testing

- Verified manually by running the script from bash, zsh, and simulating an unknown shell via `SHELL=/usr/bin/ksh`
- The binary installs successfully in all cases; only the post-install hint varies

### Checklist

- [x] Commit message follows Conventional Commits
- [x] No new dependencies introduced
- [x] Behaviour is unchanged for zsh users (existing default)
- [x] Fish users now receive correct `| source` idiom and config path
- [x] Unknown shells degrade gracefully with a warning rather than a hard exit