### PR TITLE
feat(commands): add common IaC tools to DiscoverCommon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,8 @@ go.work.sum
 # bin
 bin/
 
+# Local `go build -o typo` artifact at repository root
+/typo
+
 # local caches
 .cache/

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -492,6 +492,36 @@ func runReadmeParserCase(t *testing.T, env *e2eEnv, name, command, stderrFile, w
 	assertE2EStdoutEquals(t, result, want, "unexpected stderr parser result")
 }
 
+// TestE2EIaCCommandTypoFix smoke-tests that IaC tools added to DiscoverCommon()
+// participate in edit-distance correction without relying on PATH discovery.
+func TestE2EIaCCommandTypoFix(t *testing.T) {
+	env := newE2EEnv(t)
+
+	cases := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{name: "pulumi", command: "pulimi version", want: "pulumi version\n"},
+		{name: "tofu", command: "tofuu apply", want: "tofu apply\n"},
+		{name: "terragrunt", command: "terragurnt plan", want: "terragrunt plan\n"},
+		{name: "terramate", command: "terramte list", want: "terramate list\n"},
+		{name: "opentofu", command: "opentfu version", want: "opentofu version\n"},
+		{name: "cdktf", command: "cdkf get", want: "cdktf get\n"},
+		{name: "packer", command: "packr build", want: "packer build\n"},
+		{name: "vault", command: "vaut status", want: "vault status\n"},
+		{name: "consul", command: "consl members", want: "consul members\n"},
+		{name: "nomad", command: "nomaad status", want: "nomad status\n"},
+		{name: "crossplane", command: "crossplne version", want: "crossplane version\n"},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			runReadmeFixCase(t, env, tt.command, tt.want)
+		})
+	}
+}
+
 func TestE2EReadmeExamples(t *testing.T) {
 	env := newE2EEnv(t)
 

--- a/internal/commands/known.go
+++ b/internal/commands/known.go
@@ -85,6 +85,8 @@ func DiscoverCommon() []string {
 		"mkdir", "rm", "cp", "mv", "touch",
 		"echo", "printf", "env", "export",
 		"kubectl", "helm", "terraform", "ansible",
+		"terragrunt", "terramate", "opentofu", "tofu", "pulumi", "cdktf",
+		"crossplane", "packer", "vault", "consul", "nomad",
 		"aws", "gcloud", "az",
 	}
 }

--- a/internal/commands/known_test.go
+++ b/internal/commands/known_test.go
@@ -34,7 +34,11 @@ func TestDiscoverCommon(t *testing.T) {
 		t.Error("Expected some common commands")
 	}
 
-	for _, expected := range []string{"git", "xargs", "aws", "gcloud", "az"} {
+	for _, expected := range []string{
+		"git", "xargs", "aws", "gcloud", "az",
+		"terragrunt", "terramate", "opentofu", "tofu", "pulumi", "cdktf",
+		"crossplane", "packer", "vault", "consul", "nomad",
+	} {
 		found := false
 		for _, cmd := range cmds {
 			if cmd == expected {
@@ -122,7 +126,11 @@ func TestIsCommonCommand(t *testing.T) {
 	if !IsCommonCommand("docker") {
 		t.Fatal("Expected docker to be a common command")
 	}
-	for _, cmd := range []string{"aws", "gcloud", "az"} {
+	for _, cmd := range []string{
+		"aws", "gcloud", "az", "terraform",
+		"terragrunt", "terramate", "opentofu", "tofu", "pulumi", "cdktf",
+		"crossplane", "packer", "vault", "consul", "nomad",
+	} {
 		if !IsCommonCommand(cmd) {
 			t.Fatalf("Expected %s to be a common command", cmd)
 		}


### PR DESCRIPTION
## Summary

Extends `DiscoverCommon()` with widely used infrastructure-as-code and HashiCorp-style CLIs (terragrunt, terramate, opentofu, tofu, pulumi, cdktf, crossplane, packer, vault, consul, nomad) so typo corrections for those binary names work immediately via the seeded command list, without waiting for PATH discovery.

## Related issue

Fixes https://github.com/yuluo-yx/typo/issues/4

## What changed

- Add the new tool names to the common command slice in `internal/commands/known.go`.
- Extend `TestDiscoverCommon` / `TestIsCommonCommand` in `internal/commands/known_test.go`.
- Add e2e smoke cases in `TestE2EIaCCommandTypoFix` for edit-distance fixes on several of the new commands.
- Ignore a local root `go build -o typo` artifact via `/typo` in `.gitignore`.

## Testing performed

```text
go test ./...
```

All packages passed, including `e2e`.

## Checklist

- [x] I linked the related issue with `Fixes #...` or `Closes #...` when applicable.
- [x] I reviewed the testing standards in `CONTRIBUTING.md` and ran the relevant checks for this change.
- [x] I ran lint and formatting checks locally when they apply, or I explained why they were skipped.
- [x] I updated documentation or comments for any user-facing change, or this change does not require docs.
- [x] I reviewed the commit conventions in `CONTRIBUTING.md` and used the expected format for my commits and PR title.
- [x] I kept this PR focused on a single logical change, or I explained why broader scope was necessary.
