### PR TITLE
ci(benchmark): add nightly benchmark regression workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,159 @@
+name: Benchmark
+
+permissions:
+  contents: read
+  issues: write
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+    if: github.repository == 'yuluo-yx/typo'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./tools/github-setup-deps
+      - run: make download
+
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@latest
+
+      - name: Restore baseline
+        uses: actions/cache/restore@v4
+        with:
+          path: baseline.txt
+          key: benchmark-baseline-${{ github.run_id }}
+          restore-keys: benchmark-baseline-
+
+      - name: Check baseline exists
+        id: check
+        run: |
+          if [ -f baseline.txt ] && [ -s baseline.txt ]; then
+            echo "has_baseline=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_baseline=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run benchmarks
+        run: |
+          go test -bench=. -benchmem -count=6 -run='^$' -timeout=30m ./benchmarks/ \
+            | tee current.txt
+
+      - name: Compare with baseline
+        if: steps.check.outputs.has_baseline == 'true'
+        id: compare
+        run: |
+          echo "=== benchstat comparison ==="
+          benchstat baseline.txt current.txt 2>&1 | tee comparison.txt || true
+
+          if grep -qE '\+[0-9]+\.[0-9]+%' comparison.txt; then
+            echo "regression=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "regression=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open regression issue
+        if: steps.compare.outputs.regression == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const comparison = fs.readFileSync('comparison.txt', 'utf8');
+
+            const regressions = comparison.split('\n')
+              .filter(line => /\+[0-9]+\.[0-9]+%/.test(line))
+              .map(line => line.trim())
+              .filter(Boolean);
+
+            const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+            const { data: pulls } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 20,
+            });
+            const recentPRs = pulls
+              .filter(pr => pr.merged_at && new Date(pr.merged_at) > new Date(since))
+              .map(pr => `- #${pr.number} ${pr.title} (by @${pr.user.login})`);
+
+            const runURL = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const date = new Date().toISOString().slice(0, 10);
+
+            let body = `The nightly benchmark run detected a performance regression.\n\n`;
+            body += `**Workflow run:** ${runURL}\n\n`;
+            body += `### Regressed benchmarks\n\n`;
+            body += '```\n' + regressions.join('\n') + '\n```\n\n';
+            body += `### Full comparison\n\n`;
+            body += '<details>\n<summary>benchstat output</summary>\n\n';
+            body += '```\n' + comparison.trim() + '\n```\n\n</details>\n\n';
+            body += `### Potential causes\n\n`;
+            if (recentPRs.length > 0) {
+              body += `PRs merged in the last 24 hours:\n\n${recentPRs.join('\n')}\n`;
+            } else {
+              body += `No PRs were merged in the last 24 hours. The regression may stem from an earlier change or environmental variance.\n`;
+            }
+
+            const { data: openIssues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'kind/performance',
+              state: 'open',
+              per_page: 20,
+            });
+            const existing = openIssues.find(i => i.title.startsWith('Benchmark regression detected'));
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `### Update — ${date}\n\n${body}`,
+              });
+              core.info(`Commented on existing issue #${existing.number}`);
+            } else {
+              const { data: created } = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `Benchmark regression detected (${date})`,
+                body,
+                labels: ['kind/performance'],
+                assignees: ['yuluo-yx'],
+              });
+              core.info(`Created issue #${created.number}`);
+            }
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: |
+            current.txt
+            baseline.txt
+            comparison.txt
+          if-no-files-found: ignore
+          retention-days: 90
+
+      - name: Update baseline
+        if: steps.compare.outputs.regression != 'true'
+        run: cp current.txt baseline.txt
+
+      - name: Save baseline
+        if: steps.compare.outputs.regression != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: baseline.txt
+          key: benchmark-baseline-${{ github.run_id }}
+
+      - name: Fail on regression
+        if: steps.compare.outputs.regression == 'true'
+        run: |
+          echo "::error::Benchmark regression detected against the stored baseline."
+          cat comparison.txt
+          exit 1


### PR DESCRIPTION
## Summary

Add a nightly CI workflow that runs Go benchmarks, compares results against a cached baseline using `benchstat`, and automatically opens a GitHub issue when a performance regression is detected.

Closes #64

## What changed

- Added `.github/workflows/benchmark.yml` with a nightly schedule (`0 12 * * *` UTC) and `workflow_dispatch` trigger.
- Benchmarks run with `-count=6` for statistical significance and are compared against the previous baseline via `benchstat`.
- On regression: an issue is created (or an existing open regression issue is updated) assigned to @yuluo-yx, including the regressed benchmarks, full `benchstat` output, and PRs merged in the last 24 hours as potential causes.
- On success: the baseline is updated in the GitHub Actions cache for the next run.
- Results (current, baseline, comparison) are uploaded as artifacts with 90-day retention.

## Testing performed

```text
# Validated workflow YAML syntax
# Verified the workflow follows the same patterns as build-and-test.yml
# (uses pinned checkout action, ./tools/github-setup-deps composite action, make download)
# First run should be triggered manually via workflow_dispatch to seed the initial baseline
```

## Checklist

- [x] I linked the related issue with `Closes #...` or `Fixes #...` when applicable.
- [x] I reviewed the testing standards in `CONTRIBUTING.md` and ran the relevant checks for this change.
- [x] I ran lint and formatting checks locally when they apply, or I explained why they were skipped.
- [x] I updated documentation or comments for any user-facing change, or this change does not require docs.
- [x] I reviewed the commit conventions in `CONTRIBUTING.md` and used the expected format for my commits and PR title.
- [x] I kept this PR focused on a single logical change, or I explained why broader scope was necessary.