### PR TITLE
fix(ci): reduce benchmark false positives with 10% threshold and rolling baseline

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,21 +40,40 @@ jobs:
 
       - name: Run benchmarks
         run: |
-          go test -bench=. -benchmem -count=6 -run='^$' -timeout=30m ./benchmarks/ \
+          go test -bench=. -benchmem -count=10 -run='^$' -timeout=30m ./benchmarks/ \
             | tee current.txt
 
       - name: Compare with baseline
         if: steps.check.outputs.has_baseline == 'true'
         id: compare
+        env:
+          REGRESSION_THRESHOLD: 10
         run: |
           echo "=== benchstat comparison ==="
           benchstat baseline.txt current.txt 2>&1 | tee comparison.txt || true
 
-          if grep -qE '\+[0-9]+\.[0-9]+%' comparison.txt; then
+          if grep -E '\+[0-9]+\.[0-9]+%.*\(p=0\.0[0-4]' comparison.txt | \
+             awk -v t="$REGRESSION_THRESHOLD" '{
+               for (i=1; i<=NF; i++) {
+                 if ($i ~ /^\+[0-9.]+%$/) {
+                   v = $i; gsub(/[+%]/, "", v)
+                   if (v+0 >= t) { found=1; exit }
+                 }
+               }
+             } END { exit !found }'; then
             echo "regression=true" >> "$GITHUB_OUTPUT"
           else
             echo "regression=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Update baseline
+        run: cp current.txt baseline.txt
+
+      - name: Save baseline
+        uses: actions/cache/save@v4
+        with:
+          path: baseline.txt
+          key: benchmark-baseline-${{ github.run_id }}
 
       - name: Open regression issue
         if: steps.compare.outputs.regression == 'true'
@@ -64,8 +83,13 @@ jobs:
             const fs = require('fs');
             const comparison = fs.readFileSync('comparison.txt', 'utf8');
 
+            const THRESHOLD = 10;
             const regressions = comparison.split('\n')
-              .filter(line => /\+[0-9]+\.[0-9]+%/.test(line))
+              .filter(line => {
+                const pctMatch = line.match(/\+(\d+\.\d+)%/);
+                const pMatch = line.match(/\(p=0\.0[0-4]/);
+                return pctMatch && pMatch && parseFloat(pctMatch[1]) >= THRESHOLD;
+              })
               .map(line => line.trim())
               .filter(Boolean);
 
@@ -85,7 +109,7 @@ jobs:
             const runURL = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const date = new Date().toISOString().slice(0, 10);
 
-            let body = `The nightly benchmark run detected a performance regression.\n\n`;
+            let body = `The nightly benchmark run detected a performance regression (≥${THRESHOLD}% with p<0.05).\n\n`;
             body += `**Workflow run:** ${runURL}\n\n`;
             body += `### Regressed benchmarks\n\n`;
             body += '```\n' + regressions.join('\n') + '\n```\n\n';
@@ -140,20 +164,9 @@ jobs:
           if-no-files-found: ignore
           retention-days: 90
 
-      - name: Update baseline
-        if: steps.compare.outputs.regression != 'true'
-        run: cp current.txt baseline.txt
-
-      - name: Save baseline
-        if: steps.compare.outputs.regression != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: baseline.txt
-          key: benchmark-baseline-${{ github.run_id }}
-
       - name: Fail on regression
         if: steps.compare.outputs.regression == 'true'
         run: |
-          echo "::error::Benchmark regression detected against the stored baseline."
+          echo "::error::Benchmark regression detected (>=10% with p<0.05) against the stored baseline."
           cat comparison.txt
           exit 1


### PR DESCRIPTION
## Summary

Fix false-positive benchmark regression alerts caused by environmental noise on shared GitHub Actions runners. The nightly CI was flagging regressions of 1-6% with no code changes, due to an overly sensitive detection threshold and a stale-baseline feedback loop.

Fixes #82

## What changed

- **Regression threshold raised to ≥10% with p<0.05**: The old `grep` matched any `+X.X%` line in benchstat output regardless of magnitude or statistical significance. The new detection uses `grep` + `awk` to require both a statistically significant result (p<0.05) and a magnitude of at least 10%, which clears the observed ~6% noise ceiling on shared runners.
- **Rolling baseline (always update)**: Previously the baseline froze when a regression was detected, creating a feedback loop where every subsequent run compared against an increasingly stale snapshot. The baseline now updates after every run, so each nightly compares against the previous day.
- **Issue body reflects filtering criteria**: The JavaScript that constructs the regression issue now applies the same 10%/p<0.05 filter, and the issue description states the threshold used.

## Testing performed

Validated the regex and awk logic against the benchstat output from the false-positive issue #82:
- `+5.60% (p=0.002)` → correctly filtered out (below 10% threshold)
- `+0.64% (p=0.015)` → correctly filtered out
- `geomean +1.04%` → correctly filtered out (no p-value)
- A hypothetical `+12.50% (p=0.002)` → would correctly trigger an alert

## Checklist

- [x] I linked the related issue with `Fixes #82`.
- [x] I reviewed the testing standards in `CONTRIBUTING.md` and ran the relevant checks for this change.
- [x] I ran lint and formatting checks locally when they apply, or I explained why they were skipped.
- [x] I updated documentation or comments for any user-facing change, or this change does not require docs.
- [x] I reviewed the commit conventions in `CONTRIBUTING.md` and used the expected format for my commits and PR title.
- [x] I kept this PR focused on a single logical change, or I explained why broader scope was necessary.