### PR TITLE
chore(docs): add troubleshooting guide and upgrade notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Restart your terminal, run `typo doctor`, then press `Esc` `Esc` after a typo.
 - [Command Reference](docs/reference/commands.md)
 - [Usage Examples](docs/example/use.md)
 - [Troubleshooting](docs/troubleshooting/troubleshooting.md)
+- [Upgrading from 0.x](docs/troubleshooting/upgrade-from-0x.md)
 - [How Typo Works](docs/reference/how-it-works.md)
 
 ## Release Integrity

--- a/README_CN.md
+++ b/README_CN.md
@@ -62,6 +62,7 @@ Invoke-Expression (& typo init powershell | Out-String)
 - [命令参考](docs/reference/commands_CN.md)
 - [使用示例](docs/example/use_CN.md)
 - [问题排查](docs/troubleshooting/troubleshooting_CN.md)
+- [从 0.x 升级](docs/troubleshooting/upgrade-from-0x_CN.md)
 - [工作原理](docs/reference/how-it-works_CN.md)
 
 ## Release 完整性

--- a/docs/troubleshooting/troubleshooting.md
+++ b/docs/troubleshooting/troubleshooting.md
@@ -141,3 +141,207 @@ Additional notes:
 - bash removes its cache in the `EXIT` trap.
 - PowerShell removes its cache through the `PowerShell.Exiting` engine event.
 - If the terminal crashes or the shell is killed forcibly, stale files can remain temporarily. typo cleans up caches older than one day on the next shell start.
+
+## 6. Shell integration is not loaded
+
+Symptoms:
+
+- `typo doctor` reports `shell integration: ✗ not loaded`
+- Pressing `Esc` `Esc` does nothing
+- `echo $TYPO_SHELL_INTEGRATION` prints empty or is unset
+
+Common causes:
+
+- The shell init line (`eval "$(typo init <shell>)"`) is missing from the shell config file.
+- The init line is in the wrong file. For example, it is in `~/.bash_profile` instead of `~/.bashrc`, so non-login shells never source it.
+- `typo` is not in `PATH` when the shell starts, so `typo init` fails silently.
+- The init line is commented out or has a syntax error.
+
+Recommended fixes:
+
+1. Run `typo doctor` to check which shell is detected and what config file it expects:
+
+   ```bash
+   typo doctor
+   ```
+
+2. Add the correct init line to the matching config file:
+
+   ```bash
+   # zsh  → ~/.zshrc
+   eval "$(typo init zsh)"
+
+   # bash → ~/.bashrc
+   eval "$(typo init bash)"
+
+   # fish → ~/.config/fish/config.fish
+   typo init fish | source
+
+   # PowerShell → $PROFILE.CurrentUserCurrentHost
+   Invoke-Expression (& typo init powershell | Out-String)
+   ```
+
+3. Verify that `typo` is accessible before the init line runs:
+
+   ```bash
+   which typo    # or: command -v typo
+   ```
+
+4. Restart the terminal or source the config:
+
+   ```bash
+   source ~/.zshrc   # or ~/.bashrc
+   ```
+
+## 7. `Esc` `Esc` does not trigger correction
+
+Symptoms:
+
+- Shell integration is loaded (`TYPO_SHELL_INTEGRATION=1`), but pressing `Esc` `Esc` does nothing.
+- The keybinding works intermittently or only in certain terminal windows.
+
+Common causes:
+
+- The terminal emulator or IDE intercepts `Esc` before the shell receives it.
+- The shell is running in **vi mode**, where `Esc` switches to normal mode instead of triggering typo.
+- In bash, the readline `keyseq-timeout` is too short for the shell to recognize the double-`Esc` sequence.
+- Another plugin or custom binding has overridden the `Esc` `Esc` sequence.
+
+Recommended fixes:
+
+1. Check whether your terminal captures `Esc`. In JetBrains IDEs, see [section 1](#1-why-does-pressing-the-esc-key-exit-the-terminal-in-idea) and [section 3](#3-why-doesnt-the-esc-binding-work-in-a-jetbrains-remote-ide-terminal-launched-via-gateway).
+
+2. If your shell uses **vi mode**, `Esc` is consumed by the mode switch. Bind typo to an alternative key instead:
+
+   ```bash
+   # zsh
+   bindkey '^T' _typo_fix_command
+
+   # bash
+   bind -x '"\C-t":"_typo_fix_command"'
+
+   # fish
+   bind ctrl-t _typo_fix_command
+
+   # PowerShell
+   Set-PSReadLineKeyHandler -Chord Ctrl+t -ScriptBlock { __typo_FixCommand }
+   ```
+
+3. In **bash 4.x**, increase the keyseq timeout if the double-`Esc` is not recognized reliably:
+
+   ```bash
+   bind 'set keyseq-timeout 200'
+   ```
+
+4. Check for conflicting keybindings:
+
+   ```bash
+   # zsh — list Esc bindings
+   bindkey -L | grep '\\e\\e'
+
+   # bash — list Esc bindings
+   bind -p | grep '\\e\\e'
+
+   # fish — list escape bindings
+   bind | grep escape
+   ```
+
+   If another plugin has claimed `\e\e`, load `typo init` after that plugin so typo's binding takes priority, or switch to an alternative key as shown above.
+
+## 8. Permissions issues with `~/.typo`
+
+Symptoms:
+
+- `typo config set` or `typo rules add` fails with a permission error.
+- `typo fix` prints `typo: invalid config file` or cannot write history.
+- `typo config gen` cannot create `~/.typo/config.json`.
+
+Common causes:
+
+- `~/.typo` was created by a different user (for example, an accidental `sudo typo config gen`).
+- The directory or its files have overly restrictive permissions.
+- The filesystem is read-only or full.
+
+Recommended fixes:
+
+1. Check ownership and permissions:
+
+   ```bash
+   ls -la ~/.typo
+   ```
+
+2. Fix ownership if needed:
+
+   ```bash
+   sudo chown -R "$(whoami)" ~/.typo
+   chmod 755 ~/.typo
+   chmod 600 ~/.typo/*.json
+   ```
+
+3. If the config file is corrupt, typo automatically quarantines it on the next load (renamed to `config.json.corrupt-<timestamp>`). You can regenerate defaults:
+
+   ```bash
+   typo config gen --force
+   ```
+
+4. If the directory cannot be created at all, check disk space and filesystem state:
+
+   ```bash
+   df -h ~
+   ```
+
+Additional notes:
+
+- typo stores all user data under `~/.typo/`: `config.json`, `rules.json`, `history.json`, and subcommand caches.
+- All files are created with mode `0600` and the directory with mode `0755`.
+- `typo uninstall` removes the entire `~/.typo/` directory.
+
+## 9. Conflicts with other shell plugins
+
+Symptoms:
+
+- typo stops working after installing another shell plugin.
+- Another plugin breaks when typo integration is loaded.
+- `Esc` `Esc` triggers the wrong plugin or does nothing.
+- Bash prompt behaves erratically or shows delayed output.
+
+Common causes:
+
+- Another plugin overrides the `Esc` `Esc` keybinding.
+- In bash, another plugin replaces `PROMPT_COMMAND` instead of appending to it, which removes typo's `_typo_precmd` hook.
+- In bash, another plugin installs its own `DEBUG` trap, overriding typo's `_typo_debug_trap`.
+- Another plugin's `preexec`/`precmd` hooks interfere with typo's stderr redirection.
+
+Recommended fixes:
+
+1. **Load order matters.** Place `eval "$(typo init <shell>)"` as the **last** shell integration line in your config file. This ensures typo's keybindings and hooks take priority:
+
+   ```bash
+   # ~/.zshrc
+   source ~/.oh-my-zsh/oh-my-zsh.sh    # other plugins first
+   eval "$(typo init zsh)"              # typo last
+   ```
+
+2. **Bash `PROMPT_COMMAND` conflicts.** typo prepends `_typo_precmd` to `PROMPT_COMMAND` and preserves existing values. If another plugin overwrites `PROMPT_COMMAND` entirely after typo loads, typo's precmd hook is lost. Reorder the plugins so typo loads last, or manually re-add the hook:
+
+   ```bash
+   PROMPT_COMMAND="_typo_precmd; $PROMPT_COMMAND"
+   ```
+
+3. **Bash `DEBUG` trap conflicts.** typo chains the previous `DEBUG` trap when it installs its own. If another plugin installs a `DEBUG` trap after typo, it may break the chain. Load typo last to avoid this, or verify the trap chain:
+
+   ```bash
+   trap -p DEBUG
+   ```
+
+4. **Keybinding conflicts.** If another plugin uses `Esc` `Esc`, bind typo to a different key as described in [section 7](#7-esc-esc-does-not-trigger-correction).
+
+5. **Stderr redirection conflicts.** typo redirects stderr through `tee` to capture error output. Plugins that also redirect fd 2 (stderr) may interfere. If you see duplicated or missing error output, try loading typo after the conflicting plugin.
+
+Known compatible plugins:
+
+- oh-my-zsh, Prezto, zsh-autosuggestions, zsh-syntax-highlighting
+- bash-preexec (typo chains the existing DEBUG trap)
+- fisher, oh-my-fish
+
+If you encounter a specific incompatibility, please open an issue with the plugin name and shell version.

--- a/docs/troubleshooting/troubleshooting_CN.md
+++ b/docs/troubleshooting/troubleshooting_CN.md
@@ -142,3 +142,207 @@ Set-PSReadLineKeyHandler -Chord Ctrl+t -ScriptBlock { __typo_FixCommand }
 - 正常退出时，zsh 会在 `zshexit` 钩子里删除缓存，bash 会在 `EXIT` trap 中删除缓存，PowerShell 会在 `PowerShell.Exiting` 事件里删除缓存。
 - 如果终端崩溃、shell 被强制杀死，或者系统异常中断，退出钩子可能来不及执行，这种场景下残留旧文件是可以接受的。
 - typo 会在后续 shell 启动时清理一天前遗留的旧缓存，避免 `/tmp` 长期堆积。
+
+## 6. Shell 集成没有加载
+
+常见现象：
+
+- `typo doctor` 显示 `shell integration: ✗ not loaded`
+- 按 `Esc` `Esc` 没有任何反应
+- `echo $TYPO_SHELL_INTEGRATION` 输出为空或未设置
+
+常见原因：
+
+- shell 配置文件中缺少 init 行（`eval "$(typo init <shell>)"`）。
+- init 行写在了错误的文件里。例如写在 `~/.bash_profile` 而不是 `~/.bashrc`，导致非登录 shell 不会加载。
+- shell 启动时 `typo` 不在 `PATH` 中，`typo init` 静默失败。
+- init 行被注释掉或存在语法错误。
+
+推荐处理方式：
+
+1. 运行 `typo doctor` 查看检测到的 shell 以及期望的配置文件：
+
+   ```bash
+   typo doctor
+   ```
+
+2. 将正确的 init 行添加到对应的配置文件中：
+
+   ```bash
+   # zsh  → ~/.zshrc
+   eval "$(typo init zsh)"
+
+   # bash → ~/.bashrc
+   eval "$(typo init bash)"
+
+   # fish → ~/.config/fish/config.fish
+   typo init fish | source
+
+   # PowerShell → $PROFILE.CurrentUserCurrentHost
+   Invoke-Expression (& typo init powershell | Out-String)
+   ```
+
+3. 确认 `typo` 在 init 行执行前可用：
+
+   ```bash
+   which typo    # 或: command -v typo
+   ```
+
+4. 重启终端或重新 source 配置文件：
+
+   ```bash
+   source ~/.zshrc   # 或 ~/.bashrc
+   ```
+
+## 7. `Esc` `Esc` 无法触发纠正
+
+常见现象：
+
+- Shell 集成已加载（`TYPO_SHELL_INTEGRATION=1`），但按 `Esc` `Esc` 没有反应。
+- 快捷键时灵时不灵，或只在某些终端窗口生效。
+
+常见原因：
+
+- 终端模拟器或 IDE 在 shell 接收到 `Esc` 之前就拦截了它。
+- Shell 运行在 **vi 模式** 下，`Esc` 会切换模式而不是触发 typo。
+- 在 bash 中，readline 的 `keyseq-timeout` 设置过短，导致无法识别连续按两次 `Esc`。
+- 其他插件或自定义绑定覆盖了 `Esc` `Esc` 序列。
+
+推荐处理方式：
+
+1. 检查终端是否拦截了 `Esc`。JetBrains IDE 请参考 [第 1 节](#1-在-idea-终端中按-esc-会退出终端) 和 [第 3 节](#3-jetbraines-通过-gateway-启动的-remote-ide-终端里绑定-esc-键无效)。
+
+2. 如果 shell 使用 **vi 模式**，`Esc` 会被模式切换消费。改为绑定其他键：
+
+   ```bash
+   # zsh
+   bindkey '^T' _typo_fix_command
+
+   # bash
+   bind -x '"\C-t":"_typo_fix_command"'
+
+   # fish
+   bind ctrl-t _typo_fix_command
+
+   # PowerShell
+   Set-PSReadLineKeyHandler -Chord Ctrl+t -ScriptBlock { __typo_FixCommand }
+   ```
+
+3. 在 **bash 4.x** 中，如果双 `Esc` 不能稳定识别，尝试增大 keyseq 超时：
+
+   ```bash
+   bind 'set keyseq-timeout 200'
+   ```
+
+4. 检查是否存在冲突的按键绑定：
+
+   ```bash
+   # zsh — 列出 Esc 相关绑定
+   bindkey -L | grep '\\e\\e'
+
+   # bash — 列出 Esc 相关绑定
+   bind -p | grep '\\e\\e'
+
+   # fish — 列出 escape 相关绑定
+   bind | grep escape
+   ```
+
+   如果其他插件占用了 `\e\e`，可以将 `typo init` 放在该插件之后加载以确保 typo 的绑定优先生效，或改用其他键（见上方示例）。
+
+## 8. `~/.typo` 权限问题
+
+常见现象：
+
+- `typo config set` 或 `typo rules add` 报权限错误。
+- `typo fix` 输出 `typo: invalid config file` 或无法写入历史记录。
+- `typo config gen` 无法创建 `~/.typo/config.json`。
+
+常见原因：
+
+- `~/.typo` 由其他用户创建（例如误用 `sudo typo config gen`）。
+- 目录或文件权限过于严格。
+- 文件系统只读或磁盘空间已满。
+
+推荐处理方式：
+
+1. 检查所有权和权限：
+
+   ```bash
+   ls -la ~/.typo
+   ```
+
+2. 如有需要，修复所有权：
+
+   ```bash
+   sudo chown -R "$(whoami)" ~/.typo
+   chmod 755 ~/.typo
+   chmod 600 ~/.typo/*.json
+   ```
+
+3. 如果配置文件已损坏，typo 在下次加载时会自动将其隔离（重命名为 `config.json.corrupt-<时间戳>`）。可以重新生成默认配置：
+
+   ```bash
+   typo config gen --force
+   ```
+
+4. 如果目录完全无法创建，检查磁盘空间和文件系统状态：
+
+   ```bash
+   df -h ~
+   ```
+
+补充说明：
+
+- typo 的所有用户数据存储在 `~/.typo/` 下：`config.json`、`rules.json`、`history.json` 以及子命令缓存。
+- 所有文件创建时使用 `0600` 权限，目录使用 `0755` 权限。
+- `typo uninstall` 会删除整个 `~/.typo/` 目录。
+
+## 9. 与其他 shell 插件冲突
+
+常见现象：
+
+- 安装其他 shell 插件后 typo 停止工作。
+- 加载 typo 集成后，其他插件出现异常。
+- `Esc` `Esc` 触发了错误的插件或完全无响应。
+- Bash 提示符行为异常或输出延迟。
+
+常见原因：
+
+- 其他插件覆盖了 `Esc` `Esc` 按键绑定。
+- 在 bash 中，其他插件直接替换了 `PROMPT_COMMAND` 而不是追加，导致 typo 的 `_typo_precmd` 钩子被移除。
+- 在 bash 中，其他插件安装了自己的 `DEBUG` trap，覆盖了 typo 的 `_typo_debug_trap`。
+- 其他插件的 `preexec`/`precmd` 钩子干扰了 typo 的 stderr 重定向。
+
+推荐处理方式：
+
+1. **加载顺序很重要。** 将 `eval "$(typo init <shell>)"` 放在配置文件中所有 shell 集成行的 **最后**。这样可以确保 typo 的按键绑定和钩子优先生效：
+
+   ```bash
+   # ~/.zshrc
+   source ~/.oh-my-zsh/oh-my-zsh.sh    # 其他插件在前
+   eval "$(typo init zsh)"              # typo 在最后
+   ```
+
+2. **Bash `PROMPT_COMMAND` 冲突。** typo 会在 `PROMPT_COMMAND` 前追加 `_typo_precmd` 并保留已有值。如果其他插件在 typo 之后完全覆写了 `PROMPT_COMMAND`，typo 的 precmd 钩子就会丢失。调整插件加载顺序让 typo 最后加载，或手动重新添加钩子：
+
+   ```bash
+   PROMPT_COMMAND="_typo_precmd; $PROMPT_COMMAND"
+   ```
+
+3. **Bash `DEBUG` trap 冲突。** typo 在安装自己的 `DEBUG` trap 时会链接之前已有的 trap。如果其他插件在 typo 之后安装了 `DEBUG` trap，可能会打断链接。让 typo 最后加载，或检查 trap 链：
+
+   ```bash
+   trap -p DEBUG
+   ```
+
+4. **按键绑定冲突。** 如果其他插件也使用 `Esc` `Esc`，请按 [第 7 节](#7-esc-esc-无法触发纠正) 的说明将 typo 绑定到其他键。
+
+5. **stderr 重定向冲突。** typo 通过 `tee` 重定向 stderr 来捕获错误输出。如果其他插件也重定向 fd 2（stderr），可能会产生干扰。如果出现错误输出重复或丢失，请将 typo 放在冲突插件之后加载。
+
+已知兼容的插件：
+
+- oh-my-zsh、Prezto、zsh-autosuggestions、zsh-syntax-highlighting
+- bash-preexec（typo 会链接已有的 DEBUG trap）
+- fisher、oh-my-fish
+
+如果你遇到特定的兼容性问题，请附上插件名称和 shell 版本提交 issue。

--- a/docs/troubleshooting/upgrade-from-0x.md
+++ b/docs/troubleshooting/upgrade-from-0x.md
@@ -1,0 +1,162 @@
+# Upgrading from 0.x to v1
+
+English | [简体中文](upgrade-from-0x_CN.md)
+
+This guide covers breaking changes and migration steps for users upgrading from Typo 0.x releases to v1.
+
+## Before you upgrade
+
+1. Check your current version:
+
+   ```bash
+   typo version
+   ```
+
+2. Back up your local data directory:
+
+   ```bash
+   cp -r ~/.typo ~/.typo.backup
+   ```
+
+3. Note which shell integration line you use. Run `typo doctor` to confirm.
+
+## Breaking changes
+
+### Config file format
+
+Typo 0.1.x did not have a config file. If you are upgrading from 0.1.x, no migration is needed — v1 creates `~/.typo/config.json` on first use with sensible defaults.
+
+If you are upgrading from 0.2.x, the config file format (`~/.typo/config.json`) is forward-compatible with v1. The following keys are unchanged:
+
+- `similarity_threshold`
+- `max_edit_distance`
+- `max_fix_passes`
+- `keyboard`
+- `history.enabled`
+- `rules.<scope>.enabled`
+
+v1 may introduce additional config keys. Unknown keys in your existing file are preserved but ignored.
+
+If your config file is invalid JSON, v1 quarantines it automatically (renamed to `config.json.corrupt-<timestamp>`) and falls back to defaults. You can regenerate a fresh config with:
+
+```bash
+typo config gen --force
+```
+
+### CLI changes
+
+| 0.x command | v1 equivalent | Notes |
+|---|---|---|
+| `typo fix <command>` | `typo fix <command>` | Unchanged |
+| `typo learn <from> <to>` | `typo learn <from> <to>` | Unchanged |
+| N/A | `typo config list\|get\|set\|reset\|gen` | New in 0.2.0, stable in v1 |
+| N/A | `typo rules list\|add\|remove\|enable\|disable` | New in 0.2.0, stable in v1 |
+| N/A | `typo history list\|clear` | New in 0.2.0, stable in v1 |
+| N/A | `typo doctor` | New in v1 |
+| N/A | `typo uninstall` | New in v1 |
+
+If you have scripts that call `typo fix`, they continue to work as before. The `-s <file>` and `--exit-code <n>` flags are unchanged.
+
+### Shell integration
+
+The shell init commands are unchanged from 0.2.x:
+
+```bash
+# zsh
+eval "$(typo init zsh)"
+
+# bash
+eval "$(typo init bash)"
+
+# fish
+typo init fish | source
+
+# PowerShell
+Invoke-Expression (& typo init powershell | Out-String)
+```
+
+Changes to be aware of:
+
+- **fish support** is new in v1. If you were using zsh or bash on 0.x and want to switch to fish, add the fish init line above.
+- **`TYPO_SHELL_INTEGRATION` environment variable** is set to `1` by all shell integrations in v1. `typo doctor` checks for this variable. If you have custom scripts that check for typo's presence, use this variable.
+- **`TYPO_ACTIVE_SHELL` environment variable** is set by the fish integration to help typo detect the shell. Other shells use `$SHELL` detection.
+- Shell integration scripts now set owner-tracking variables (`TYPO_STDERR_CACHE_OWNER`, `TYPO_ORIG_STDERR_FD_OWNER`) to safely handle nested shell sessions. These are internal and should not be set manually.
+
+### Directory structure
+
+The `~/.typo/` directory layout has expanded:
+
+```text
+~/.typo/
+├── config.json          (new in 0.2.0)
+├── rules.json           (user rules, previously learned corrections)
+├── usage_history.json   (correction history)
+└── subcommands.json     (cached subcommand discovery)
+```
+
+- If upgrading from 0.1.x, `rules.json` is the only file that may already exist. All other files are created automatically.
+- `subcommands.json` is a cache file. Deleting it is safe — it will be regenerated on next use.
+- The directory permissions should be `0755` and file permissions should be `0600`.
+
+### Rule scopes
+
+v1 introduces additional builtin rule scopes beyond what was available in 0.2.0:
+
+| Scope | Since |
+|---|---|
+| `git`, `docker`, `npm` | 0.1.0 |
+| `yarn`, `kubectl`, `cargo`, `brew` | 0.2.0 |
+| `helm`, `terraform`, `python`, `pip`, `go`, `java`, `system` | 0.2.0 |
+
+All scopes are enabled by default. If you previously disabled a scope, your setting is preserved.
+
+### Install methods
+
+v1 supports these install methods (all verified by `typo doctor`):
+
+- `curl` install script (macOS / Linux)
+- Windows PowerShell quick-install script
+- Homebrew (planned)
+- Manual GitHub Release binary
+
+If you used the install script, re-run it to get the latest version:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/yuluo-yx/typo/main/tools/scripts/install.sh | bash
+```
+
+## Post-upgrade checklist
+
+After upgrading:
+
+1. Restart your terminal (or source your shell config).
+2. Run `typo doctor` to verify the new version is loaded and all checks pass.
+3. Run `typo version` to confirm the version number.
+4. Run `typo config list` to verify your settings carried over.
+5. Run `typo rules list` to verify your custom rules are intact.
+
+## Rolling back
+
+If you need to revert to 0.x:
+
+1. Restore your backup:
+
+   ```bash
+   rm -rf ~/.typo
+   mv ~/.typo.backup ~/.typo
+   ```
+
+2. Install the specific 0.x version:
+
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/yuluo-yx/typo/main/tools/scripts/install.sh | bash -s -- -s 0.2.0
+   ```
+
+3. Restart your terminal.
+
+## Related docs
+
+- [Troubleshooting](troubleshooting.md)
+- [Command Reference](../reference/commands.md)
+- [How Typo Works](../reference/how-it-works.md)
+- [Quick Start](../getting-started/quick-start.md)

--- a/docs/troubleshooting/upgrade-from-0x_CN.md
+++ b/docs/troubleshooting/upgrade-from-0x_CN.md
@@ -1,0 +1,162 @@
+# 从 0.x 升级到 v1
+
+[English](upgrade-from-0x.md) | 简体中文
+
+本指南说明从 Typo 0.x 版本升级到 v1 时的破坏性变更和迁移步骤。
+
+## 升级前准备
+
+1. 确认当前版本：
+
+   ```bash
+   typo version
+   ```
+
+2. 备份本地数据目录：
+
+   ```bash
+   cp -r ~/.typo ~/.typo.backup
+   ```
+
+3. 记录当前使用的 shell 集成行。运行 `typo doctor` 确认。
+
+## 破坏性变更
+
+### 配置文件格式
+
+Typo 0.1.x 没有配置文件。如果从 0.1.x 升级，无需迁移 — v1 会在首次使用时自动创建 `~/.typo/config.json` 并使用合理的默认值。
+
+如果从 0.2.x 升级，配置文件格式（`~/.typo/config.json`）与 v1 向前兼容。以下键名保持不变：
+
+- `similarity_threshold`
+- `max_edit_distance`
+- `max_fix_passes`
+- `keyboard`
+- `history.enabled`
+- `rules.<scope>.enabled`
+
+v1 可能会引入额外的配置键。已有文件中的未知键会被保留但不会被当前版本使用。
+
+如果配置文件包含无效 JSON，v1 会自动将其隔离（重命名为 `config.json.corrupt-<时间戳>`），并回退到默认配置。可以通过以下命令重新生成配置：
+
+```bash
+typo config gen --force
+```
+
+### CLI 变更
+
+| 0.x 命令 | v1 对应命令 | 说明 |
+|---|---|---|
+| `typo fix <command>` | `typo fix <command>` | 不变 |
+| `typo learn <from> <to>` | `typo learn <from> <to>` | 不变 |
+| 无 | `typo config list\|get\|set\|reset\|gen` | 0.2.0 新增，v1 中稳定 |
+| 无 | `typo rules list\|add\|remove\|enable\|disable` | 0.2.0 新增，v1 中稳定 |
+| 无 | `typo history list\|clear` | 0.2.0 新增，v1 中稳定 |
+| 无 | `typo doctor` | v1 新增 |
+| 无 | `typo uninstall` | v1 新增 |
+
+如果你的脚本调用了 `typo fix`，升级后无需修改。`-s <file>` 和 `--exit-code <n>` 参数保持不变。
+
+### Shell 集成
+
+Shell init 命令与 0.2.x 保持一致：
+
+```bash
+# zsh
+eval "$(typo init zsh)"
+
+# bash
+eval "$(typo init bash)"
+
+# fish
+typo init fish | source
+
+# PowerShell
+Invoke-Expression (& typo init powershell | Out-String)
+```
+
+需要注意的变更：
+
+- **fish 支持** 在 v1 中新增。如果你之前在 0.x 上使用 zsh 或 bash，想要切换到 fish，请添加上方的 fish init 行。
+- **`TYPO_SHELL_INTEGRATION` 环境变量** 在 v1 中由所有 shell 集成设置为 `1`。`typo doctor` 会检查此变量。如果你有自定义脚本需要检测 typo 是否存在，可以使用此变量。
+- **`TYPO_ACTIVE_SHELL` 环境变量** 由 fish 集成设置，帮助 typo 识别当前 shell。其他 shell 通过 `$SHELL` 检测。
+- Shell 集成脚本现在设置了 owner 追踪变量（`TYPO_STDERR_CACHE_OWNER`、`TYPO_ORIG_STDERR_FD_OWNER`），用于安全处理嵌套 shell 会话。这些是内部变量，不应手动设置。
+
+### 目录结构
+
+`~/.typo/` 目录布局已扩展：
+
+```text
+~/.typo/
+├── config.json          （0.2.0 新增）
+├── rules.json           （用户规则，之前学习的纠正）
+├── usage_history.json   （纠正历史）
+└── subcommands.json     （缓存的子命令发现结果）
+```
+
+- 如果从 0.1.x 升级，`rules.json` 是可能已存在的唯一文件。其他文件会自动创建。
+- `subcommands.json` 是缓存文件，删除是安全的 — 下次使用时会重新生成。
+- 目录权限应为 `0755`，文件权限应为 `0600`。
+
+### 规则作用域
+
+v1 引入了比 0.2.0 更多的内置规则作用域：
+
+| 作用域 | 起始版本 |
+|---|---|
+| `git`、`docker`、`npm` | 0.1.0 |
+| `yarn`、`kubectl`、`cargo`、`brew` | 0.2.0 |
+| `helm`、`terraform`、`python`、`pip`、`go`、`java`、`system` | 0.2.0 |
+
+所有作用域默认启用。如果你之前禁用了某个作用域，设置会被保留。
+
+### 安装方式
+
+v1 支持以下安装方式（均可通过 `typo doctor` 验证）：
+
+- `curl` 安装脚本（macOS / Linux）
+- Windows PowerShell 快速安装脚本
+- Homebrew（计划中）
+- 手动下载 GitHub Release 二进制文件
+
+如果使用安装脚本，重新运行即可获取最新版本：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/yuluo-yx/typo/main/tools/scripts/install.sh | bash
+```
+
+## 升级后检查清单
+
+升级完成后：
+
+1. 重启终端（或重新 source shell 配置文件）。
+2. 运行 `typo doctor` 验证新版本已加载且所有检查通过。
+3. 运行 `typo version` 确认版本号。
+4. 运行 `typo config list` 验证配置已正确继承。
+5. 运行 `typo rules list` 验证自定义规则完好。
+
+## 回退方法
+
+如果需要恢复到 0.x：
+
+1. 恢复备份：
+
+   ```bash
+   rm -rf ~/.typo
+   mv ~/.typo.backup ~/.typo
+   ```
+
+2. 安装指定的 0.x 版本：
+
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/yuluo-yx/typo/main/tools/scripts/install.sh | bash -s -- -s 0.2.0
+   ```
+
+3. 重启终端。
+
+## 相关文档
+
+- [问题排查](troubleshooting_CN.md)
+- [命令参考](../reference/commands_CN.md)
+- [工作原理](../reference/how-it-works_CN.md)
+- [快速上手](../getting-started/quick-start_CN.md)


### PR DESCRIPTION
## Summary

Expand the troubleshooting guide with four new sections covering common user issues, and add upgrade notes for users migrating from 0.x to v1. Both EN and CN versions are updated.

Closes #68

## What changed

- Added four new troubleshooting sections (EN + CN) to `docs/troubleshooting/troubleshooting.md`:
  - **Section 6** — Shell integration not loaded (missing init line, wrong config file, typo not in PATH)
  - **Section 7** — `Esc Esc` not triggering (terminal/IDE interception, vi mode, keyseq-timeout, conflicting bindings)
  - **Section 8** — Permissions issues with `~/.typo` (ownership, corrupt config quarantine, disk space)
  - **Section 9** — Conflicts with other shell plugins (keybinding, PROMPT_COMMAND, DEBUG trap, stderr redirection, load order)
- Created `docs/troubleshooting/upgrade-from-0x.md` (EN + CN) covering:
  - Config file format compatibility between 0.x and v1
  - CLI changes table (new subcommands in 0.2.0 and v1)
  - Shell integration changes (fish support, new env vars)
  - Directory structure expansion
  - Rule scope additions
  - Install method updates
  - Post-upgrade checklist and rollback instructions
- Added upgrade notes link to the Documentation section in both `README.md` and `README_CN.md`

## Testing performed

This is a docs-only change. Verified that:
- All internal cross-links between EN/CN pairs are correct
- Section anchor links within the troubleshooting doc are consistent
- No linter errors reported on the changed files

```text
# Verified no linter errors on all changed files
ReadLints on all 6 changed files — no errors
```

## Checklist

- [x] I linked the related issue with `Closes #...` or `Fixes #...` when applicable.
- [x] I reviewed the testing standards in `CONTRIBUTING.md` and ran the relevant checks for this change.
- [x] I ran lint and formatting checks locally when they apply, or I explained why they were skipped.
- [x] I updated documentation or comments for any user-facing change, or this change does not require docs.
- [x] I reviewed the commit conventions in `CONTRIBUTING.md` and used the expected format for my commits and PR title.
- [x] I kept this PR focused on a single logical change, or I explained why broader scope was necessary.