### PR TITLE
feat(parser): add generic stderr parser for broad CLI coverage

### DIFF
--- a/internal/parser/generic.go
+++ b/internal/parser/generic.go
@@ -1,0 +1,100 @@
+package parser
+
+import (
+	"regexp"
+	"strings"
+
+	itypes "github.com/yuluo-yx/typo/internal/types"
+)
+
+// GenericParser catches "did you mean" hints emitted by any CLI, covering tools
+// that do not have a dedicated parser (e.g. rustup, cargo, helm, gh, kubectl,
+// pnpm, poetry, pip).
+type GenericParser struct {
+	// inlineRegex matches suggestions on the same line as the hint phrase,
+	// e.g. "Did you mean 'target'?" or "maybe you meant `build`".
+	inlineRegex *regexp.Regexp
+	// nextLineRegex matches suggestions that appear on the line immediately
+	// following "Did you mean this?" or "Did you mean one of these?",
+	// e.g. helm, gh, kubectl, poetry.
+	nextLineRegex *regexp.Regexp
+}
+
+// NewGenericParser creates a new GenericParser.
+func NewGenericParser() *GenericParser {
+	return &GenericParser{
+		inlineRegex: regexp.MustCompile(
+			"(?i)(?:did you mean|maybe you meant|perhaps you meant)" +
+				`\s+['` + "`" + `"]([\w][\w-]*)['` + "`" + `"][?!.]?`,
+		),
+		nextLineRegex: regexp.MustCompile(
+			`(?i)did you mean (?:this|one of these)\?[^\n]*\n[ \t]+([\w][\w-]*)`,
+		),
+	}
+}
+
+// Name returns the parser name.
+func (p *GenericParser) Name() string {
+	return "generic"
+}
+
+// Parse parses generic error output.
+func (p *GenericParser) Parse(ctx itypes.ParserContext) itypes.ParserResult {
+	cmd := ctx.Command
+	stderr := ctx.Stderr
+
+	suggested := p.extractSuggestion(stderr)
+	if suggested == "" {
+		return itypes.ParserResult{Fixed: false}
+	}
+
+	// Ignore flag-correction hints (e.g. pnpm suggesting --save for --savde).
+	if strings.HasPrefix(suggested, "-") {
+		return itypes.ParserResult{Fixed: false}
+	}
+
+	parts := strings.Fields(cmd)
+	if len(parts) < 2 {
+		return itypes.ParserResult{Fixed: false}
+	}
+	binary := parts[0]
+
+	call, err := parseShellCall(cmd)
+	if err != nil {
+		// Fallback: reconstruct as "binary suggestion [rest...]".
+		fixed := binary + " " + suggested
+		if len(parts) > 2 {
+			fixed += " " + strings.Join(parts[2:], " ")
+		}
+		return itypes.ParserResult{
+			Fixed:   true,
+			Command: fixed,
+			Message: "generic suggested: " + suggested,
+		}
+	}
+
+	// expected is empty so replaceSubcommand replaces whatever positional
+	// argument is at the subcommand position, regardless of its current value.
+	fixed, ok := call.replaceSubcommand(binary, "", suggested, genericParserOptionsWithValues)
+	if !ok {
+		return itypes.ParserResult{Fixed: false}
+	}
+
+	return itypes.ParserResult{
+		Fixed:   true,
+		Command: fixed,
+		Message: "generic suggested: " + suggested,
+	}
+}
+
+// extractSuggestion returns the first plausible correction found in stderr,
+// or an empty string if none is found.
+func (p *GenericParser) extractSuggestion(stderr string) string {
+	if m := p.inlineRegex.FindStringSubmatch(stderr); len(m) >= 2 {
+		return m[1]
+	}
+	if m := p.nextLineRegex.FindStringSubmatch(stderr); len(m) >= 2 {
+		return m[1]
+	}
+	return ""
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -14,6 +14,7 @@ func NewRegistry() *Registry {
 	r.Register(NewDockerParser())
 	r.Register(NewNpmParser())
 	r.Register(NewPermissionParser())
+	r.Register(NewGenericParser())
 	return r
 }
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -724,3 +724,152 @@ func TestNpmParser_ParseJustSuggestionNoParts(t *testing.T) {
 		t.Error("Expected not to fix when npm has no subcommand to replace")
 	}
 }
+
+func TestGenericParser_Name(t *testing.T) {
+	p := NewGenericParser()
+	if p.Name() != "generic" {
+		t.Errorf("Name() = %q, want 'generic'", p.Name())
+	}
+}
+
+func TestGenericParser_Parse(t *testing.T) {
+	p := NewGenericParser()
+
+	tests := []struct {
+		name    string
+		cmd     string
+		stderr  string
+		wantFix bool
+		wantCmd string
+	}{
+		{
+			// rustup: single-quoted inline hint
+			name:    "rustup did you mean",
+			cmd:     "rustup taget list",
+			stderr:  "error: Unknown command 'taget'. Did you mean 'target'?",
+			wantFix: true,
+			wantCmd: "rustup target list",
+		},
+		{
+			// cargo: backtick-quoted inline hint with indentation
+			name:    "cargo did you mean",
+			cmd:     "cargo buid",
+			stderr:  "error: no such subcommand: `buid`\n\n\tDid you mean `build`?\n",
+			wantFix: true,
+			wantCmd: "cargo build",
+		},
+		{
+			// helm: next-line hint after "Did you mean this?"
+			name:    "helm did you mean this",
+			cmd:     "helm upgraed myrelease ./chart",
+			stderr:  "Error: unknown command \"upgraed\" for \"helm\"\n\nDid you mean this?\n\tupgrade\n\nRun 'helm --help' for usage.",
+			wantFix: true,
+			wantCmd: "helm upgrade myrelease ./chart",
+		},
+		{
+			// gh: next-line hint after "Did you mean this?" — wrong token at position 1
+			name:    "gh did you mean this",
+			cmd:     "gh pr-lst",
+			stderr:  "unknown command \"pr-lst\" for \"gh\"\n\nDid you mean this?\n\tpr-list\n",
+			wantFix: true,
+			wantCmd: "gh pr-list",
+		},
+		{
+			// kubectl: next-line hint after "Did you mean this?"
+			name:    "kubectl did you mean this",
+			cmd:     "kubectl appli -f pod.yaml",
+			stderr:  "Error: unknown command \"appli\" for \"kubectl\"\n\nDid you mean this?\n\tapply\n",
+			wantFix: true,
+			wantCmd: "kubectl apply -f pod.yaml",
+		},
+		{
+			// poetry: next-line hint after "Did you mean one of these?"
+			name:    "poetry did you mean one of these",
+			cmd:     "poetry addd requests",
+			stderr:  "The command \"addd\" is not defined.\nDid you mean one of these?\n    add\n    addr\n",
+			wantFix: true,
+			wantCmd: "poetry add requests",
+		},
+		{
+			// pip: "maybe you meant" double-quoted inline hint
+			name:    "pip maybe you meant",
+			cmd:     "pip insatll requests",
+			stderr:  "ERROR: unknown command \"insatll\" - maybe you meant \"install\"\n",
+			wantFix: true,
+			wantCmd: "pip install requests",
+		},
+		{
+			// Flag suggestion should be ignored — not a subcommand fix
+			name:    "pnpm flag suggestion ignored",
+			cmd:     "pnpm install --savde",
+			stderr:  "ERR_PNPM_UNKNOWN_OPTIONS  Unknown option: '--savde'\nDid you mean '--save'?\n",
+			wantFix: false,
+		},
+		{
+			// No stderr hint at all
+			name:    "no hint in stderr",
+			cmd:     "sometool badcmd",
+			stderr:  "error: unrecognized command\n",
+			wantFix: false,
+		},
+		{
+			// Single-word command with no subcommand to replace
+			name:    "command with no subcommand",
+			cmd:     "rustup",
+			stderr:  "Did you mean 'target'?",
+			wantFix: false,
+		},
+		{
+			// Git commands should not be double-handled — git parser runs first,
+			// but even if it fell through, we verify generic produces a valid fix
+			name:    "generic does not break on git-style stderr",
+			cmd:     "git comit -m 'msg'",
+			stderr:  "git: 'comit' is not a git command.\nDid you mean 'commit'?\n",
+			wantFix: true,
+			wantCmd: "git commit -m 'msg'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := p.Parse(itypes.ParserContext{Command: tt.cmd, Stderr: tt.stderr})
+			if result.Fixed != tt.wantFix {
+				t.Errorf("Parse().Fixed = %v, want %v", result.Fixed, tt.wantFix)
+			}
+			if tt.wantFix && result.Command != tt.wantCmd {
+				t.Errorf("Parse().Command = %q, want %q", result.Command, tt.wantCmd)
+			}
+		})
+	}
+}
+
+func TestGenericParser_RegisteredLast(t *testing.T) {
+	r := NewRegistry()
+
+	// A git error must still be handled by the git parser (not the generic one)
+	result := r.Parse(itypes.ParserContext{
+		Command: "git comit -m 'msg'",
+		Stderr:  "git: 'comit' is not a git command. See 'git --help'.\n\nThe most similar command is\n\tcommit\n",
+	})
+	if !result.Fixed {
+		t.Fatal("Expected registry to fix git error")
+	}
+	if result.Parser != "git" {
+		t.Errorf("Expected git parser to handle git error, got %q", result.Parser)
+	}
+
+	// An unknown CLI with a generic hint must be handled by the generic parser
+	result = r.Parse(itypes.ParserContext{
+		Command: "rustup taget list",
+		Stderr:  "error: Unknown command 'taget'. Did you mean 'target'?",
+	})
+	if !result.Fixed {
+		t.Fatal("Expected registry to fix rustup error via generic parser")
+	}
+	if result.Command != "rustup target list" {
+		t.Errorf("Expected 'rustup target list', got %q", result.Command)
+	}
+	if result.Parser != "generic" {
+		t.Errorf("Expected generic parser to handle rustup error, got %q", result.Parser)
+	}
+}

--- a/internal/parser/shell.go
+++ b/internal/parser/shell.go
@@ -131,3 +131,5 @@ var npmParserOptionsWithValues = map[string]bool{
 	"--userconfig": true,
 	"-C":           true,
 }
+
+var genericParserOptionsWithValues = map[string]bool{}


### PR DESCRIPTION
## Summary

Closes #100

Adds a `GenericParser` that reads "did you mean" hints directly from a CLI's own stderr output, correcting the typo with higher confidence than edit-distance guessing. It runs **last** in the parser registry so all four dedicated parsers (git, docker, npm, permission) still take precedence.

## What it does

Matches two families of hint patterns found across many CLIs:

**Inline** - suggestion on the same line as the hint phrase, in any quote style:
- `Did you mean 'target'?` (rustup)
- `Did you mean 'build'?` (cargo backtick-style)
- `maybe you meant "install"` (pip)
- `perhaps you meant 'X'`

**Next-line** - suggestion on the indented line after `Did you mean this?` or `Did you mean one of these?`:
- helm, gh, kubectl, poetry

Extracts the suggestion and replaces the subcommand in the original command using the same token-aware `replaceSubcommand` helper the other parsers use. Ignores flag-correction hints (suggestions starting with `-`) to avoid rewriting a subcommand when the CLI is correcting a flag typo (e.g. pnpm `--savde -> --save`). Falls back to a safe string reconstruction when the command cannot be shell-parsed.

## What it cannot do

- **Nested subcommands** - the parser always targets the first positional argument after the binary. A command like `gh pr pll` where `pll` is at depth 2 will not be fixed; that requires a dedicated parser with knowledge of the CLI's subcommand tree.
- **Global flags that consume values** - without knowing any specific CLI's flag schema, a global flag like `--namespace foo` can cause `foo` to be misidentified as the subcommand. Simple invocations without global flags work correctly.
- **Non-standard hint phrasing** - CLIs that emit correction hints in formats not covered by the two regex families will fall through to edit-distance matching as before.

## Test plan

- `TestGenericParser_Parse` - 11 cases covering rustup, cargo, helm, gh, kubectl, poetry, pip, pnpm (flag hint ignored), no hint, single-word command, git-style stderr
- `TestGenericParser_RegisteredLast` - verifies git parser still wins for git errors, and generic parser fires for unknown CLIs
- `TestGenericParser_Name` - parser identity
- Full `go test ./...` passes