### PR TITLE
feat(parser-git): feat git pull set upstream bug

### DIFF
--- a/docs/example/use.md
+++ b/docs/example/use.md
@@ -87,6 +87,23 @@ If you wish to set tracking information for this branch you can do so with:
 
 Press `Esc` `Esc`, and Typo can add the suggested upstream automatically.
 
+## `git pull --rebase`
+
+When Git refuses to pull because the local and remote branches diverged:
+
+```shell
+$ git pull
+hint: You have divergent branches and need to specify how to reconcile them.
+hint: You can pass --rebase, --no-rebase, or --ff-only on the command line.
+fatal: Need to specify how to reconcile divergent branches.
+```
+
+Press `Esc` `Esc`, and Typo can retry the same pull with a command-level rebase strategy.
+
+```shell
+git pull --rebase
+```
+
 ## No permission? Use `sudo`
 
 > You finish typing a command and then realize you do not have permission.

--- a/docs/example/use_CN.md
+++ b/docs/example/use_CN.md
@@ -87,6 +87,23 @@ If you wish to set tracking information for this branch you can do so with:
 
 这时按两次 `Esc`，Typo 会自动补全建议的 upstream 设置。
 
+## `git pull --rebase`
+
+当本地分支和远端分支已经分叉，Git 会拒绝继续 pull：
+
+```shell
+$ git pull
+hint: You have divergent branches and need to specify how to reconcile them.
+hint: You can pass --rebase, --no-rebase, or --ff-only on the command line.
+fatal: Need to specify how to reconcile divergent branches.
+```
+
+这时按两次 `Esc`，Typo 会用命令级 rebase 策略重试同一次 pull。
+
+```shell
+git pull --rebase
+```
+
 ## 没有权限？自动补 `sudo`
 
 > 命令本身没问题，只是执行时缺少权限。

--- a/docs/reference/how-it-works.md
+++ b/docs/reference/how-it-works.md
@@ -63,7 +63,7 @@ Typo can extract suggestions from real `stderr` output when available.
 
 Currently documented parser coverage:
 
-- `git`: `did you mean...`, missing upstream, and related suggestions
+- `git`: `did you mean...`, missing upstream, divergent pull rebase, and related suggestions
 - `docker`: unknown command suggestions
 - `npm`: command-not-found suggestions
 

--- a/docs/reference/how-it-works_CN.md
+++ b/docs/reference/how-it-works_CN.md
@@ -56,7 +56,7 @@ cd $HOME/project
 
 当前已有文档覆盖的解析器包括：
 
-- `git`：`did you mean...`、缺少 upstream 等建议
+- `git`：`did you mean...`、缺少 upstream、分叉 pull rebase 等建议
 - `docker`：未知命令建议
 - `npm`：命令未找到建议
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -683,6 +683,7 @@ func TestE2EReadmeExamples(t *testing.T) {
 	}
 
 	gitStderr := env.writeTempFile(t, "git.stderr", "git: 'remove' is not a git command.\n\nThe most similar command is\n\tremote\n")
+	gitPullRebaseStderr := env.writeTempFile(t, "git-pull-rebase.stderr", "hint: You have divergent branches and need to specify how to reconcile them.\nhint: You can do so by running one of the following commands sometime before\nhint: your next pull:\nhint:\nhint:   git config pull.rebase false  # merge\nhint:   git config pull.rebase true   # rebase\nhint:   git config pull.ff only       # fast-forward only\nhint:\nhint: You can replace \"git config\" with \"git config --global\" to set a default\nhint: preference for all repositories. You can also pass --rebase, --no-rebase,\nhint: or --ff-only on the command line to override the configured default per\nhint: invocation.\nfatal: Need to specify how to reconcile divergent branches.\n")
 	dockerStderr := env.writeTempFile(t, "docker.stderr", "unknown command: imagesa\n\nDid you mean: images?")
 	npmStderr := env.writeTempFile(t, "npm.stderr", "npm ERR! Did you mean list?")
 	permissionStderr := env.writeTempFile(t, "permission.stderr", "mkdir: 1: Permission denied\n")
@@ -694,6 +695,7 @@ func TestE2EReadmeExamples(t *testing.T) {
 		want       string
 	}{
 		{name: "git stderr parser", command: "git remove -v", stderrFile: gitStderr, want: "git remote -v\n"},
+		{name: "git pull rebase stderr parser", command: "git pull", stderrFile: gitPullRebaseStderr, want: "git pull --rebase\n"},
 		{name: "docker stderr parser", command: "docker imagesa", stderrFile: dockerStderr, want: "docker images\n"},
 		{name: "npm stderr parser", command: "npm ist --depth=0", stderrFile: npmStderr, want: "npm list --depth=0\n"},
 		{name: "permission stderr parser", command: "mkdir 1", stderrFile: permissionStderr, want: "sudo mkdir 1\n"},

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -221,6 +221,20 @@ func TestEngine_FixWithParser_NoUpstreamTargetsPullOnly(t *testing.T) {
 	}
 }
 
+func TestEngine_FixWithParser_NoUpstreamRejectsPlaceholderRemote(t *testing.T) {
+	eng := NewEngine(
+		WithParser(parser.NewRegistry()),
+	)
+
+	result := eng.FixWithContext(itypes.ParserContext{
+		Command: "git remove -v && git pull",
+		Stderr:  "There is no tracking information for the current branch.\nPlease specify which branch you want to merge with.\nSee git-pull(1) for details.\n\n    git pull <remote> <branch>\n\nIf you wish to set tracking information for this branch you can do so with:\n\n    git branch --set-upstream-to=<remote>/<branch> 0426-yuluo/fix\n",
+	})
+	if result.Fixed {
+		t.Fatalf("Expected placeholder remote to stay unchanged, got %+v", result)
+	}
+}
+
 func TestEngine_FixWithParser_NoMatch(t *testing.T) {
 	eng := NewEngine(
 		WithParser(parser.NewRegistry()),

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -221,7 +221,7 @@ func TestEngine_FixWithParser_NoUpstreamTargetsPullOnly(t *testing.T) {
 	}
 }
 
-func TestEngine_FixWithParser_NoUpstreamRejectsPlaceholderRemote(t *testing.T) {
+func TestEngine_FixWithParser_NoUpstreamDefaultsPlaceholderRemoteToOrigin(t *testing.T) {
 	eng := NewEngine(
 		WithParser(parser.NewRegistry()),
 	)
@@ -230,8 +230,31 @@ func TestEngine_FixWithParser_NoUpstreamRejectsPlaceholderRemote(t *testing.T) {
 		Command: "git remove -v && git pull",
 		Stderr:  "There is no tracking information for the current branch.\nPlease specify which branch you want to merge with.\nSee git-pull(1) for details.\n\n    git pull <remote> <branch>\n\nIf you wish to set tracking information for this branch you can do so with:\n\n    git branch --set-upstream-to=<remote>/<branch> 0426-yuluo/fix\n",
 	})
-	if result.Fixed {
-		t.Fatalf("Expected placeholder remote to stay unchanged, got %+v", result)
+	if !result.Fixed {
+		t.Fatal("Expected placeholder remote to default to origin")
+	}
+	if result.Command != "git remove -v && git pull --set-upstream origin 0426-yuluo/fix" {
+		t.Fatalf("Expected placeholder remote to default to origin, got %q", result.Command)
+	}
+}
+
+func TestEngine_FixWithParser_DivergentPullRebaseTargetsPullOnly(t *testing.T) {
+	eng := NewEngine(
+		WithParser(parser.NewRegistry()),
+	)
+
+	result := eng.FixWithContext(itypes.ParserContext{
+		Command: "git status && git pull origin main",
+		Stderr:  "hint: You have divergent branches and need to specify how to reconcile them.\nhint: You can do so by running one of the following commands sometime before\nhint: your next pull:\nhint:\nhint:   git config pull.rebase false  # merge\nhint:   git config pull.rebase true   # rebase\nhint:   git config pull.ff only       # fast-forward only\nhint:\nhint: You can replace \"git config\" with \"git config --global\" to set a default\nhint: preference for all repositories. You can also pass --rebase, --no-rebase,\nhint: or --ff-only on the command line to override the configured default per\nhint: invocation.\nfatal: Need to specify how to reconcile divergent branches.\n",
+	})
+	if !result.Fixed {
+		t.Fatal("Expected divergent pull command to be fixed")
+	}
+	if result.Command != "git status && git pull --rebase origin main" {
+		t.Fatalf("Expected rebase fix to apply only to git pull, got %q", result.Command)
+	}
+	if !result.UsedParser {
+		t.Fatal("Expected parser-assisted fix chain to retain parser usage marker")
 	}
 }
 

--- a/internal/parser/git.go
+++ b/internal/parser/git.go
@@ -102,6 +102,10 @@ func (p *GitParser) parseNoUpstream(cmd, stderr string) itypes.ParserResult {
 		localBranch = matches[3]
 	}
 
+	if p.placeholderRegex.MatchString(remote) {
+		return itypes.ParserResult{Fixed: false}
+	}
+
 	branch := upstreamBranch
 	if p.placeholderRegex.MatchString(branch) && localBranch != "" {
 		branch = localBranch

--- a/internal/parser/git.go
+++ b/internal/parser/git.go
@@ -9,19 +9,23 @@ import (
 
 // GitParser parses git command errors.
 type GitParser struct {
-	didYouMeanRegex  *regexp.Regexp
-	noUpstreamRegex  *regexp.Regexp
-	placeholderRegex *regexp.Regexp
-	notGitRepoRegex  *regexp.Regexp
+	didYouMeanRegex          *regexp.Regexp
+	noUpstreamRegex          *regexp.Regexp
+	divergentBranchesRegex   *regexp.Regexp
+	reconcileDivergenceRegex *regexp.Regexp
+	placeholderRegex         *regexp.Regexp
+	notGitRepoRegex          *regexp.Regexp
 }
 
 // NewGitParser creates a new GitParser.
 func NewGitParser() *GitParser {
 	return &GitParser{
-		didYouMeanRegex:  regexp.MustCompile(`(?s)git: '([^']+)' is not a git command\..*The most similar commands? (?:is|are)\s+(\w+)`),
-		noUpstreamRegex:  regexp.MustCompile(`git branch --set-upstream-to=([^/\s]+)/([^\s]+)(?:\s+([^\s]+))?`),
-		placeholderRegex: regexp.MustCompile(`^<[^>\s]+>$`),
-		notGitRepoRegex:  regexp.MustCompile(`fatal: not a git repository`),
+		didYouMeanRegex:          regexp.MustCompile(`(?s)git: '([^']+)' is not a git command\..*The most similar commands? (?:is|are)\s+(\w+)`),
+		noUpstreamRegex:          regexp.MustCompile(`git branch --set-upstream-to=([^/\s]+)/([^\s]+)(?:\s+([^\s]+))?`),
+		divergentBranchesRegex:   regexp.MustCompile(`(?i)You have divergent branches and need to specify how to reconcile them\.`),
+		reconcileDivergenceRegex: regexp.MustCompile(`(?i)fatal: Need to specify how to reconcile divergent branches\.`),
+		placeholderRegex:         regexp.MustCompile(`^<[^>\s]+>$`),
+		notGitRepoRegex:          regexp.MustCompile(`fatal: not a git repository`),
 	}
 }
 
@@ -47,6 +51,10 @@ func (p *GitParser) Parse(ctx itypes.ParserContext) itypes.ParserResult {
 
 	// Try to parse "no upstream" errors
 	if result := p.parseNoUpstream(cmd, stderr); result.Fixed {
+		return result
+	}
+
+	if result := p.parseDivergentPullRebase(cmd, stderr); result.Fixed {
 		return result
 	}
 
@@ -103,7 +111,7 @@ func (p *GitParser) parseNoUpstream(cmd, stderr string) itypes.ParserResult {
 	}
 
 	if p.placeholderRegex.MatchString(remote) {
-		return itypes.ParserResult{Fixed: false}
+		remote = "origin"
 	}
 
 	branch := upstreamBranch
@@ -119,6 +127,26 @@ func (p *GitParser) parseNoUpstream(cmd, stderr string) itypes.ParserResult {
 		Fixed:   true,
 		Command: cmd + " --set-upstream " + remote + " " + branch,
 		Message: "adding upstream tracking: " + remote + "/" + branch,
+	}
+}
+
+func (p *GitParser) parseDivergentPullRebase(cmd, stderr string) itypes.ParserResult {
+	if gitSubcommand(cmd) != "pull" || gitCommandHasPullReconcileFlag(cmd) {
+		return itypes.ParserResult{Fixed: false}
+	}
+	if !p.divergentBranchesRegex.MatchString(stderr) || !p.reconcileDivergenceRegex.MatchString(stderr) {
+		return itypes.ParserResult{Fixed: false}
+	}
+
+	fixed, ok := addGitPullRebaseFlag(cmd)
+	if !ok {
+		return itypes.ParserResult{Fixed: false}
+	}
+
+	return itypes.ParserResult{
+		Fixed:   true,
+		Command: fixed,
+		Message: "adding git pull rebase strategy",
 	}
 }
 
@@ -232,6 +260,58 @@ func gitCommandHasUpstreamFlag(cmd string) bool {
 	}
 
 	return false
+}
+
+func gitCommandHasPullReconcileFlag(cmd string) bool {
+	for _, part := range strings.Fields(cmd) {
+		switch {
+		case part == "--rebase", part == "--no-rebase", part == "--ff-only":
+			return true
+		case strings.HasPrefix(part, "--rebase="):
+			return true
+		}
+	}
+
+	return false
+}
+
+func addGitPullRebaseFlag(cmd string) (string, bool) {
+	if strings.HasPrefix(strings.Fields(cmd)[0], "git-pull") {
+		return addGitPrefixedPullRebaseFlag(cmd)
+	}
+
+	call, err := parseShellCall(cmd)
+	if err == nil {
+		index := findShellSubcommandIndex(call.args, "git", gitParserOptionsWithValues)
+		if index != -1 && call.args[index].Lit() == "pull" {
+			return call.insertAfterWord(index, " --rebase"), true
+		}
+	}
+
+	parts := strings.Fields(cmd)
+	for i, part := range parts {
+		if part == "pull" {
+			parts = append(parts[:i+1], append([]string{"--rebase"}, parts[i+1:]...)...)
+			return strings.Join(parts, " "), true
+		}
+	}
+
+	return "", false
+}
+
+func addGitPrefixedPullRebaseFlag(cmd string) (string, bool) {
+	call, err := parseShellCall(cmd)
+	if err == nil && len(call.args) > 0 && gitPrefixedSubcommand(call.args[0].Lit()) == "pull" {
+		return call.insertAfterWord(0, " --rebase"), true
+	}
+
+	parts := strings.Fields(cmd)
+	if len(parts) == 0 || gitPrefixedSubcommand(parts[0]) != "pull" {
+		return "", false
+	}
+
+	parts = append(parts[:1], append([]string{"--rebase"}, parts[1:]...)...)
+	return strings.Join(parts, " "), true
 }
 
 var gitGlobalOptions = map[string]bool{

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -52,10 +52,11 @@ func TestGitParser_Parse(t *testing.T) {
 			wantCmd: "git pull --set-upstream origin 0322-yuluo/inprove-add-check",
 		},
 		{
-			name:    "no upstream branch ignores placeholder remote",
+			name:    "no upstream branch defaults placeholder remote to origin",
 			cmd:     "git pull",
 			stderr:  "There is no tracking information for the current branch.\nPlease specify which branch you want to merge with.\nSee git-pull(1) for details.\n\n    git pull <remote> <branch>\n\nIf you wish to set tracking information for this branch you can do so with:\n\n    git branch --set-upstream-to=<remote>/<branch> 0426-yuluo/fix\n",
-			wantFix: false,
+			wantFix: true,
+			wantCmd: "git pull --set-upstream origin 0426-yuluo/fix",
 		},
 		{
 			name:    "no upstream branch is idempotent once fixed",
@@ -640,6 +641,124 @@ func TestGitParser_ParseNoUpstreamPlaceholderWithoutLocalBranch(t *testing.T) {
 	if result.Fixed {
 		t.Fatalf("Expected placeholder upstream without local branch to stay unchanged, got %+v", result)
 	}
+}
+
+func TestGitParser_ParseDivergentPullRebase(t *testing.T) {
+	p := NewGitParser()
+	stderr := gitDivergentPullStderr()
+
+	tests := []struct {
+		name    string
+		cmd     string
+		wantFix bool
+		wantCmd string
+	}{
+		{
+			name:    "plain pull",
+			cmd:     "git pull",
+			wantFix: true,
+			wantCmd: "git pull --rebase",
+		},
+		{
+			name:    "pull with remote and branch",
+			cmd:     "git pull origin main",
+			wantFix: true,
+			wantCmd: "git pull --rebase origin main",
+		},
+		{
+			name:    "pull with global option",
+			cmd:     "git -C repo pull origin main",
+			wantFix: true,
+			wantCmd: "git -C repo pull --rebase origin main",
+		},
+		{
+			name:    "git-pull form",
+			cmd:     "git-pull origin main",
+			wantFix: true,
+			wantCmd: "git-pull --rebase origin main",
+		},
+		{
+			name:    "already has rebase",
+			cmd:     "git pull --rebase origin main",
+			wantFix: false,
+		},
+		{
+			name:    "already has rebase mode",
+			cmd:     "git pull --rebase=merges origin main",
+			wantFix: false,
+		},
+		{
+			name:    "already has no rebase",
+			cmd:     "git pull --no-rebase origin main",
+			wantFix: false,
+		},
+		{
+			name:    "already has ff only",
+			cmd:     "git pull --ff-only origin main",
+			wantFix: false,
+		},
+		{
+			name:    "non pull command",
+			cmd:     "git fetch origin main",
+			wantFix: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := p.Parse(itypes.ParserContext{Command: tt.cmd, Stderr: stderr})
+			if result.Fixed != tt.wantFix {
+				t.Fatalf("Parse().Fixed = %v, want %v (%+v)", result.Fixed, tt.wantFix, result)
+			}
+			if tt.wantFix && result.Command != tt.wantCmd {
+				t.Fatalf("Parse().Command = %q, want %q", result.Command, tt.wantCmd)
+			}
+		})
+	}
+}
+
+func TestGitParser_ParseDivergentPullRebaseRequiresGitSignals(t *testing.T) {
+	p := NewGitParser()
+
+	tests := []struct {
+		name   string
+		stderr string
+	}{
+		{
+			name:   "missing fatal signal",
+			stderr: "hint: You have divergent branches and need to specify how to reconcile them.\n",
+		},
+		{
+			name:   "missing divergent signal",
+			stderr: "fatal: Need to specify how to reconcile divergent branches.\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := p.Parse(itypes.ParserContext{Command: "git pull", Stderr: tt.stderr})
+			if result.Fixed {
+				t.Fatalf("Expected incomplete divergent pull stderr to stay unchanged, got %+v", result)
+			}
+		})
+	}
+}
+
+func gitDivergentPullStderr() string {
+	return "$ git pull\n" +
+		"hint: You have divergent branches and need to specify how to reconcile them.\n" +
+		"hint: You can do so by running one of the following commands sometime before\n" +
+		"hint: your next pull:\n" +
+		"hint:\n" +
+		"hint:   git config pull.rebase false  # merge\n" +
+		"hint:   git config pull.rebase true   # rebase\n" +
+		"hint:   git config pull.ff only       # fast-forward only\n" +
+		"hint:\n" +
+		"hint: You can replace \"git config\" with \"git config --global\" to set a default\n" +
+		"hint: preference for all repositories. You can also pass --rebase, --no-rebase,\n" +
+		"hint: or --ff-only on the command line to override the configured default per\n" +
+		"hint: invocation.\n" +
+		"fatal: Need to specify how to reconcile divergent branches.\n"
 }
 
 func TestIsGitCommand(t *testing.T) {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -52,6 +52,12 @@ func TestGitParser_Parse(t *testing.T) {
 			wantCmd: "git pull --set-upstream origin 0322-yuluo/inprove-add-check",
 		},
 		{
+			name:    "no upstream branch ignores placeholder remote",
+			cmd:     "git pull",
+			stderr:  "There is no tracking information for the current branch.\nPlease specify which branch you want to merge with.\nSee git-pull(1) for details.\n\n    git pull <remote> <branch>\n\nIf you wish to set tracking information for this branch you can do so with:\n\n    git branch --set-upstream-to=<remote>/<branch> 0426-yuluo/fix\n",
+			wantFix: false,
+		},
+		{
 			name:    "no upstream branch is idempotent once fixed",
 			cmd:     "git pull --set-upstream origin main",
 			stderr:  "There is no tracking information for the current branch.\nPlease specify which branch you want to merge with.\nSee git-pull(1) for details.\n\n    git pull <remote> <branch>\n\nIf you wish to set tracking information for this branch, you can do so with:\n\n    git branch --set-upstream-to=origin/main main\n",

--- a/internal/parser/shell.go
+++ b/internal/parser/shell.go
@@ -41,6 +41,11 @@ func (c *shellCall) replaceWord(index int, replacement string) string {
 	return c.raw[:start] + replacement + c.raw[end:]
 }
 
+func (c *shellCall) insertAfterWord(index int, insertion string) string {
+	_, end := parserWordRange(c.args[index], len(c.raw))
+	return c.raw[:end] + insertion + c.raw[end:]
+}
+
 func (c *shellCall) replaceSubcommand(command, expected, replacement string, optionsWithValues map[string]bool) (string, bool) {
 	index := findShellSubcommandIndex(c.args, command, optionsWithValues)
 	if index == -1 {


### PR DESCRIPTION
- Fixed #137 

对于此问题，typo 没办法准确识别用 remote 还是 upstream。但是有一个办法，默认设置成 origin

- Fixed #138 

添加了 git pull --rebase 参数