### PR TITLE
fix: reduce update command binary size

### DIFF
--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -5,30 +5,27 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 )
 
-const installScriptURL = "https://raw.githubusercontent.com/yuluo-yx/typo/main/tools/scripts/install.sh"
+const (
+	installScriptURL    = "https://raw.githubusercontent.com/yuluo-yx/typo/main/tools/scripts/install.sh"
+	latestReleaseAPIURL = "https://api.github.com/repos/yuluo-yx/typo/releases/latest"
+	mainCommitAPIURL    = "https://api.github.com/repos/yuluo-yx/typo/commits/main"
+)
 
-// Injectable for testing.
 var (
-	updateHTTPDownload  func(req *http.Request) (*http.Response, error)
 	updateRunCommand    func(name string, args []string, extraEnv []string) error
 	updateCommandOutput func(name string, args []string, extraEnv []string) (string, error)
 	updateDownloadFile  func(url, dst string) error
 	updateLatestRelease func() (string, error)
 	updateMainCommit    func() (string, error)
-	updateSleep         func(d time.Duration)
 )
 
-// errStop is a sentinel that signals the chain to stop without printing an error.
 var errStop = errors.New("stop")
 
 type updateFlags struct {
@@ -46,14 +43,11 @@ const (
 )
 
 func init() {
-	downloadClient := &http.Client{Timeout: 10 * time.Minute}
-	updateHTTPDownload = downloadClient.Do
 	updateRunCommand = runUpdateCommand
 	updateCommandOutput = runUpdateCommandOutput
 	updateDownloadFile = downloadUpdateFile
 	updateLatestRelease = fetchLatestReleaseTag
 	updateMainCommit = fetchMainCommit
-	updateSleep = time.Sleep
 }
 
 func cmdUpdate(args []string) int {
@@ -177,23 +171,22 @@ func updateScriptInstall(flags updateFlags, install doctorInstallMethod) error {
 	fmt.Printf("Update target: %s\n", install.path)
 	fmt.Println("Install method: curl/install.sh")
 
+	scriptArgs, stop, err := scriptUpdateArgs(flags, mode, targetVersion)
+	if err != nil || stop {
+		return err
+	}
+	if flags.dryRun {
+		fmt.Printf("Would download: %s\n", installScriptURL)
+		fmt.Printf("Would run: TYPO_INSTALL_DIR=%s bash install.sh %s\n", targetDir, strings.Join(scriptArgs, " "))
+		return nil
+	}
+
 	if err = validateScriptUpdatePrerequisites(mode); err != nil {
 		return err
 	}
 
 	if flags.checkOnly {
 		return checkScriptInstall(flags, mode, targetVersion)
-	}
-
-	scriptArgs, stop, err := scriptUpdateArgs(flags, mode, targetVersion)
-	if err != nil || stop {
-		return err
-	}
-
-	if flags.dryRun {
-		fmt.Printf("Would download: %s\n", installScriptURL)
-		fmt.Printf("Would run: TYPO_INSTALL_DIR=%s bash install.sh %s\n", targetDir, strings.Join(scriptArgs, " "))
-		return nil
 	}
 
 	if err = runScriptUpdate(scriptArgs, targetDir); err != nil {
@@ -220,11 +213,13 @@ func validateScriptUpdatePrerequisites(mode updateMode) error {
 	if _, lookupErr := lookPath("bash"); lookupErr != nil {
 		return fmt.Errorf("bash is required to run install.sh: %w", lookupErr)
 	}
-	if mode != updateModeMain {
-		return nil
+	if mode == updateModeMain {
+		if _, lookupErr := lookPath("go"); lookupErr != nil {
+			return fmt.Errorf("go is required to build typo from main: %w", lookupErr)
+		}
 	}
-	if _, lookupErr := lookPath("go"); lookupErr != nil {
-		return fmt.Errorf("go is required to build typo from main: %w", lookupErr)
+	if _, lookupErr := lookPath("curl"); lookupErr != nil {
+		return fmt.Errorf("curl is required to download install.sh: %w", lookupErr)
 	}
 	return nil
 }
@@ -408,27 +403,18 @@ func trimVersionPrefix(version string) string {
 }
 
 func downloadUpdateFile(url, dst string) error {
-	const maxAttempts = 2
-	var lastErr error
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		err := downloadUpdateFileOnce(url, dst)
-		if err == nil {
-			return nil
-		}
-		lastErr = err
-		if attempt == maxAttempts || !shouldRetryUpdateDownload(err) {
-			break
-		}
-		updateSleep(updateDownloadBackoff(err))
+	args := []string{"-fsSL", "--retry", "1", "--retry-delay", "2", "-o", dst, url}
+	if err := updateRunCommand("curl", args, nil); err != nil {
+		return fmt.Errorf("curl download failed: %w", err)
 	}
-	return lastErr
+	return os.Chmod(dst, 0755)
 }
 
 func fetchLatestReleaseTag() (string, error) {
 	var payload struct {
 		TagName string `json:"tag_name"`
 	}
-	if err := fetchUpdateJSON("https://api.github.com/repos/yuluo-yx/typo/releases/latest", &payload); err != nil {
+	if err := fetchUpdateJSON(latestReleaseAPIURL, &payload); err != nil {
 		return "", err
 	}
 	if payload.TagName == "" {
@@ -441,7 +427,7 @@ func fetchMainCommit() (string, error) {
 	var payload struct {
 		SHA string `json:"sha"`
 	}
-	if err := fetchUpdateJSON("https://api.github.com/repos/yuluo-yx/typo/commits/main", &payload); err != nil {
+	if err := fetchUpdateJSON(mainCommitAPIURL, &payload); err != nil {
 		return "", err
 	}
 	if payload.SHA == "" {
@@ -451,106 +437,19 @@ func fetchMainCommit() (string, error) {
 }
 
 func fetchUpdateJSON(url string, out any) error {
-	const maxAttempts = 2
-	var lastErr error
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		err := fetchUpdateJSONOnce(url, out)
-		if err == nil {
-			return nil
-		}
-		lastErr = err
-		if attempt == maxAttempts || !shouldRetryUpdateDownload(err) {
-			break
-		}
-		updateSleep(updateDownloadBackoff(err))
-	}
-	return lastErr
-}
-
-func fetchUpdateJSONOnce(url string, out any) error {
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("User-Agent", "typo")
+	args := []string{"-fsSL", "--retry", "1", "--retry-delay", "2", "-H", "Accept: application/vnd.github+json", url}
 	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
+		args = append([]string{"-fsSL", "--retry", "1", "--retry-delay", "2", "-H", "Accept: application/vnd.github+json", "-H", "Authorization: Bearer " + token}, url)
 	}
 
-	resp, err := updateHTTPDownload(req)
+	output, err := updateCommandOutput("curl", args, nil)
 	if err != nil {
-		return fmt.Errorf("network error: %w (check your connection or proxy settings)", err)
+		return fmt.Errorf("curl request failed: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return updateHTTPStatusError{code: resp.StatusCode}
-	}
-	return json.NewDecoder(resp.Body).Decode(out)
-}
-
-func downloadUpdateFileOnce(url, dst string) error {
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
+	if err := json.Unmarshal([]byte(output), out); err != nil {
 		return err
 	}
-	req.Header.Set("User-Agent", "typo")
-
-	resp, err := updateHTTPDownload(req)
-	if err != nil {
-		return fmt.Errorf("network error: %w (check your connection or proxy settings)", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return updateHTTPStatusError{code: resp.StatusCode}
-	}
-
-	f, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = f.Close() }()
-
-	if _, err := io.Copy(f, resp.Body); err != nil {
-		return err
-	}
-	return os.Chmod(dst, 0755)
-}
-
-type updateHTTPStatusError struct {
-	code int
-}
-
-func (e updateHTTPStatusError) Error() string {
-	return fmt.Sprintf("HTTP %d", e.code)
-}
-
-func shouldRetryUpdateDownload(err error) bool {
-	var statusErr updateHTTPStatusError
-	if errors.As(err, &statusErr) {
-		return statusErr.code == http.StatusTooManyRequests || statusErr.code >= http.StatusInternalServerError
-	}
-	return isTimeoutError(err)
-}
-
-func updateDownloadBackoff(err error) time.Duration {
-	var statusErr updateHTTPStatusError
-	if errors.As(err, &statusErr) && statusErr.code == http.StatusTooManyRequests {
-		return 20 * time.Second
-	}
-	return 2 * time.Second
-}
-
-func isTimeoutError(err error) bool {
-	if os.IsTimeout(err) {
-		return true
-	}
-	var timeout interface {
-		Timeout() bool
-	}
-	return errors.As(err, &timeout) && timeout.Timeout()
+	return nil
 }
 
 func runUpdateCommand(name string, args []string, extraEnv []string) error {
@@ -572,8 +471,6 @@ func runUpdateCommandOutput(name string, args []string, extraEnv []string) (stri
 	output, err := cmd.Output()
 	return string(output), err
 }
-
-// --- version comparison ---
 
 func compareVersions(a, b string) int {
 	a = trimVersionPrefix(a)

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -453,7 +453,10 @@ func fetchUpdateJSON(url string, out any) error {
 }
 
 func runUpdateCommand(name string, args []string, extraEnv []string) error {
-	cmd := exec.Command(name, args...)
+	cmd, err := newUpdateCommand(name, args)
+	if err != nil {
+		return err
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if len(extraEnv) > 0 {
@@ -463,13 +466,32 @@ func runUpdateCommand(name string, args []string, extraEnv []string) error {
 }
 
 func runUpdateCommandOutput(name string, args []string, extraEnv []string) (string, error) {
-	cmd := exec.Command(name, args...)
+	cmd, err := newUpdateCommand(name, args)
+	if err != nil {
+		return "", err
+	}
 	cmd.Stderr = os.Stderr
 	if len(extraEnv) > 0 {
 		cmd.Env = append(os.Environ(), extraEnv...)
 	}
 	output, err := cmd.Output()
 	return string(output), err
+}
+
+func newUpdateCommand(name string, args []string) (*exec.Cmd, error) {
+	switch name {
+	case "bash":
+		// #nosec G702 -- update commands are restricted to this whitelist and args are constructed by update flow.
+		return exec.Command("bash", args...), nil
+	case "brew":
+		// #nosec G702 -- update commands are restricted to this whitelist and args are constructed by update flow.
+		return exec.Command("brew", args...), nil
+	case "curl":
+		// #nosec G702 -- update commands are restricted to this whitelist and args are constructed by update flow.
+		return exec.Command("curl", args...), nil
+	default:
+		return nil, fmt.Errorf("unsupported update command %q", name)
+	}
 }
 
 func compareVersions(a, b string) int {

--- a/internal/cmd/update_test.go
+++ b/internal/cmd/update_test.go
@@ -3,15 +3,12 @@ package cmd
 import (
 	"bytes"
 	"errors"
-	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
 	"runtime/debug"
 	"strings"
 	"testing"
-	"time"
 )
 
 type updateCommandCall struct {
@@ -71,7 +68,6 @@ func withUpdateTestHooks(t *testing.T, typoPath string) *[]updateCommandCall {
 	origMainCommit := updateMainCommit
 	origRunCommand := updateRunCommand
 	origCommandOutput := updateCommandOutput
-	origSleep := updateSleep
 	origVersion := version
 	origCommit := commit
 	origDate := date
@@ -106,6 +102,8 @@ func withUpdateTestHooks(t *testing.T, typoPath string) *[]updateCommandCall {
 			return "/usr/local/bin/go", nil
 		case "brew":
 			return "/opt/homebrew/bin/brew", nil
+		case "curl":
+			return "/usr/bin/curl", nil
 		default:
 			return "", os.ErrNotExist
 		}
@@ -138,7 +136,6 @@ func withUpdateTestHooks(t *testing.T, typoPath string) *[]updateCommandCall {
 		})
 		return "", nil
 	}
-	updateSleep = func(d time.Duration) {}
 
 	t.Cleanup(func() {
 		lookPath = origLookPath
@@ -149,7 +146,6 @@ func withUpdateTestHooks(t *testing.T, typoPath string) *[]updateCommandCall {
 		updateMainCommit = origMainCommit
 		updateRunCommand = origRunCommand
 		updateCommandOutput = origCommandOutput
-		updateSleep = origSleep
 		version = origVersion
 		commit = origCommit
 		date = origDate
@@ -157,6 +153,16 @@ func withUpdateTestHooks(t *testing.T, typoPath string) *[]updateCommandCall {
 	})
 
 	return &calls
+}
+
+func TestUpdateProductionCodeDoesNotImportNetHTTP(t *testing.T) {
+	data, err := os.ReadFile("update.go")
+	if err != nil {
+		t.Fatalf("read update.go: %v", err)
+	}
+	if strings.Contains(string(data), "\"net/http\"") {
+		t.Fatalf("update.go must not import net/http; use external download tools to keep the binary small")
+	}
 }
 
 func TestCmdUpdateUsesRunningBinaryInsteadOfPathLookup(t *testing.T) {
@@ -622,103 +628,29 @@ func TestCmdUpdateReportsCommandFailure(t *testing.T) {
 	}
 }
 
-func TestDownloadUpdateFileRetriesRetryableHTTPStatuses(t *testing.T) {
-	tests := []struct {
-		name      string
-		status    int
-		wantSleep time.Duration
-	}{
-		{name: "rate limited", status: http.StatusTooManyRequests, wantSleep: 20 * time.Second},
-		{name: "server error", status: http.StatusBadGateway, wantSleep: 2 * time.Second},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			origDownload := updateHTTPDownload
-			origSleep := updateSleep
-			defer func() {
-				updateHTTPDownload = origDownload
-				updateSleep = origSleep
-			}()
-
-			calls := 0
-			sleeps := make([]time.Duration, 0)
-			updateHTTPDownload = func(req *http.Request) (*http.Response, error) {
-				calls++
-				if calls == 1 {
-					return &http.Response{
-						StatusCode: tt.status,
-						Body:       io.NopCloser(strings.NewReader("")),
-					}, nil
-				}
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader("install script")),
-				}, nil
-			}
-			updateSleep = func(d time.Duration) {
-				sleeps = append(sleeps, d)
-			}
-
-			dst := filepath.Join(t.TempDir(), "install.sh")
-			if err := downloadUpdateFile(installScriptURL, dst); err != nil {
-				t.Fatalf("downloadUpdateFile failed: %v", err)
-			}
-			if calls != 2 {
-				t.Fatalf("calls = %d, want 2", calls)
-			}
-			if !reflect.DeepEqual(sleeps, []time.Duration{tt.wantSleep}) {
-				t.Fatalf("sleeps = %#v, want %#v", sleeps, []time.Duration{tt.wantSleep})
-			}
-			data, err := os.ReadFile(dst)
-			if err != nil {
-				t.Fatalf("read downloaded file: %v", err)
-			}
-			if string(data) != "install script" {
-				t.Fatalf("downloaded content = %q", string(data))
-			}
-		})
-	}
-}
-
-func TestDownloadUpdateFileRetriesTimeout(t *testing.T) {
-	origDownload := updateHTTPDownload
-	origSleep := updateSleep
-	defer func() {
-		updateHTTPDownload = origDownload
-		updateSleep = origSleep
-	}()
-
-	calls := 0
-	sleeps := make([]time.Duration, 0)
-	updateHTTPDownload = func(req *http.Request) (*http.Response, error) {
-		calls++
-		if calls == 1 {
-			return nil, timeoutTestError{}
-		}
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader("install script")),
-		}, nil
-	}
-	updateSleep = func(d time.Duration) {
-		sleeps = append(sleeps, d)
-	}
+func TestDownloadUpdateFileUsesCurl(t *testing.T) {
+	origRunCommand := updateRunCommand
+	defer func() { updateRunCommand = origRunCommand }()
 
 	dst := filepath.Join(t.TempDir(), "install.sh")
+	var got updateCommandCall
+	updateRunCommand = func(name string, args []string, extraEnv []string) error {
+		got = updateCommandCall{
+			name:     name,
+			args:     append([]string(nil), args...),
+			extraEnv: append([]string(nil), extraEnv...),
+		}
+		return os.WriteFile(dst, []byte("install script"), 0755)
+	}
+
 	if err := downloadUpdateFile(installScriptURL, dst); err != nil {
 		t.Fatalf("downloadUpdateFile failed: %v", err)
 	}
-	if calls != 2 {
-		t.Fatalf("calls = %d, want 2", calls)
+	if got.name != "curl" {
+		t.Fatalf("download command = %q, want curl", got.name)
 	}
-	if !reflect.DeepEqual(sleeps, []time.Duration{2 * time.Second}) {
-		t.Fatalf("sleeps = %#v, want %#v", sleeps, []time.Duration{2 * time.Second})
+	wantArgs := []string{"-fsSL", "--retry", "1", "--retry-delay", "2", "-o", dst, installScriptURL}
+	if !reflect.DeepEqual(got.args, wantArgs) {
+		t.Fatalf("curl args = %#v, want %#v", got.args, wantArgs)
 	}
 }
-
-type timeoutTestError struct{}
-
-func (timeoutTestError) Error() string   { return "timeout" }
-func (timeoutTestError) Timeout() bool   { return true }
-func (timeoutTestError) Temporary() bool { return true }

--- a/internal/cmd/update_test.go
+++ b/internal/cmd/update_test.go
@@ -654,3 +654,9 @@ func TestDownloadUpdateFileUsesCurl(t *testing.T) {
 		t.Fatalf("curl args = %#v, want %#v", got.args, wantArgs)
 	}
 }
+
+func TestNewUpdateCommandRejectsUnexpectedCommand(t *testing.T) {
+	if _, err := newUpdateCommand("sh", nil); err == nil {
+		t.Fatalf("expected unexpected update command to be rejected")
+	}
+}

--- a/tools/make/golang.mk
+++ b/tools/make/golang.mk
@@ -4,20 +4,21 @@
 PLATFORMS := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64
 
 CMD_PACKAGE := github.com/yuluo-yx/typo/internal/cmd
+GO_BUILD_FLAGS := -trimpath -buildvcs=false
 LDFLAGS := -s -w -X $(CMD_PACKAGE).version=$(VERSION) -X $(CMD_PACKAGE).commit=$(shell git rev-parse --short HEAD 2>/dev/null || echo "none") -X $(CMD_PACKAGE).date=$(shell date -u +%Y-%m-%d 2>/dev/null || echo "unknown")
 
 .PHONY: build
 build: ## Build the binary for the current platform
 	@$(LOG_TARGET)
 	@mkdir -p $(BUILD_DIR)/$(shell go env GOOS)-$(shell go env GOARCH)
-	$(GO) build -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/$(shell go env GOOS)-$(shell go env GOARCH)/$(BINARY_NAME) ./cmd/typo
+	$(GO) build $(GO_BUILD_FLAGS) -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/$(shell go env GOOS)-$(shell go env GOARCH)/$(BINARY_NAME) ./cmd/typo
 
 .PHONY: verify-version-metadata
 verify-version-metadata: ## Verify build-time version metadata is injected into the binary
 	@$(LOG_TARGET)
 	@tmp_dir="$$(mktemp -d)"; \
 	trap 'rm -rf "$$tmp_dir"' EXIT; \
-	$(GO) build -ldflags="$(LDFLAGS)" -o "$$tmp_dir/$(BINARY_NAME)" ./cmd/typo; \
+	$(GO) build $(GO_BUILD_FLAGS) -ldflags="$(LDFLAGS)" -o "$$tmp_dir/$(BINARY_NAME)" ./cmd/typo; \
 	output="$$("$$tmp_dir/$(BINARY_NAME)" version)"; \
 	case "$$output" in \
 		*"typo $(VERSION) "*) ;; \
@@ -27,7 +28,7 @@ verify-version-metadata: ## Verify build-time version metadata is injected into 
 .PHONY: install
 install: ## Install the binary to GOPATH/bin
 	@$(LOG_TARGET)
-	$(GO) install -ldflags="$(LDFLAGS)" ./cmd/typo
+	$(GO) install $(GO_BUILD_FLAGS) -ldflags="$(LDFLAGS)" ./cmd/typo
 
 .PHONY: build-all
 build-all: ## Build for all supported platforms
@@ -37,37 +38,37 @@ build-all: build-linux-amd64 build-linux-arm64 build-darwin-amd64 build-darwin-a
 build-linux-amd64: ## build typo for linux/amd64
 	@$(LOG_TARGET)
 	@mkdir -p $(BUILD_DIR)/linux-amd64
-	GOOS=linux GOARCH=amd64 $(GO) build -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/linux-amd64/$(BINARY_NAME) ./cmd/typo
+	GOOS=linux GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/linux-amd64/$(BINARY_NAME) ./cmd/typo
 
 .PHONY: build-linux-arm64
 build-linux-arm64: ## build typo for linux/arm64
 	@$(LOG_TARGET)
 	@mkdir -p $(BUILD_DIR)/linux-arm64
-	GOOS=linux GOARCH=arm64 $(GO) build -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/linux-arm64/$(BINARY_NAME) ./cmd/typo
+	GOOS=linux GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/linux-arm64/$(BINARY_NAME) ./cmd/typo
 
 .PHONY: build-darwin-amd64
 build-darwin-amd64: ## build typo for darwin/amd64
 	@$(LOG_TARGET)
 	@mkdir -p $(BUILD_DIR)/darwin-amd64
-	GOOS=darwin GOARCH=amd64 $(GO) build -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/darwin-amd64/$(BINARY_NAME) ./cmd/typo
+	GOOS=darwin GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/darwin-amd64/$(BINARY_NAME) ./cmd/typo
 
 .PHONY: build-darwin-arm64
 build-darwin-arm64: ## build typo for darwin/arm64
 	@$(LOG_TARGET)
 	@mkdir -p $(BUILD_DIR)/darwin-arm64
-	GOOS=darwin GOARCH=arm64 $(GO) build -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/darwin-arm64/$(BINARY_NAME) ./cmd/typo
+	GOOS=darwin GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/darwin-arm64/$(BINARY_NAME) ./cmd/typo
 
 .PHONY: build-windows-amd64
 build-windows-amd64: ## build typo for windows/amd64
 	@$(LOG_TARGET)
 	@mkdir -p $(BUILD_DIR)/windows-amd64
-	GOOS=windows GOARCH=amd64 $(GO) build -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/windows-amd64/$(BINARY_NAME).exe ./cmd/typo
+	GOOS=windows GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/windows-amd64/$(BINARY_NAME).exe ./cmd/typo
 
 .PHONY: build-windows-arm64
 build-windows-arm64: ## build typo for windows/arm64
 	@$(LOG_TARGET)
 	@mkdir -p $(BUILD_DIR)/windows-arm64
-	GOOS=windows GOARCH=arm64 $(GO) build -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/windows-arm64/$(BINARY_NAME).exe ./cmd/typo
+	GOOS=windows GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/windows-arm64/$(BINARY_NAME).exe ./cmd/typo
 
 ##@ test
 


### PR DESCRIPTION
## Summary
- replace the in-process Go HTTP update client with external curl calls so net/http, crypto/tls, and crypto/x509 stay out of the main binary
- keep typo update behavior for script and Homebrew installs while preserving version metadata injection
- add build flags (-trimpath -buildvcs=false) and tests guarding against net/http returning to update.go

## Size check
- darwin/arm64: 3.3M (3,465,730 bytes)
- linux/arm64: 3.3M (3,473,592 bytes)
- windows/amd64: 3.6M (3,744,256 bytes)

## Test Plan
- go test ./...
- go test ./internal/cmd -run 'Test(Update|CmdUpdate|CompareVersions|SplitVersion|DetectDoctorInstallMethod)'
- make verify-version-metadata
- make build-all
- go list -deps ./cmd/typo | rg '^(net/http|crypto/tls|crypto/x509)$' => NOT_FOUND