### PR TITLE
fix: tighten cli validation and bash exit trap

### DIFF
--- a/install/typo.bash
+++ b/install/typo.bash
@@ -341,6 +341,14 @@ _typo_bashexit() {
     unset _TYPO_STDERR_FIFO
 }
 
+_typo_bash_exit_trap() {
+    _typo_bashexit
+
+    if [[ -n "${_TYPO_PREV_EXIT_TRAP:-}" ]]; then
+        eval -- "$_TYPO_PREV_EXIT_TRAP"
+    fi
+}
+
 _typo_debug_trap() {
     # Guard against recursive DEBUG trap execution.
     if [[ "${_TYPO_DEBUG_ACTIVE:-0}" -eq 1 ]]; then
@@ -394,15 +402,16 @@ _typo_install_exit_hook() {
     local current_exit_trap
 
     current_exit_trap=$(trap -p EXIT)
-    if [[ "$current_exit_trap" == *"_typo_bashexit"* ]]; then
+    if [[ "$current_exit_trap" == *"_typo_bashexit"* || "$current_exit_trap" == *"_typo_bash_exit_trap"* ]]; then
         return
     fi
 
+    _TYPO_PREV_EXIT_TRAP=""
     if [[ "$current_exit_trap" =~ ^trap\ --\ \'(.*)\'\ EXIT$ ]]; then
-        trap "_typo_bashexit; ${BASH_REMATCH[1]}" EXIT
-    else
-        trap '_typo_bashexit' EXIT
+        _TYPO_PREV_EXIT_TRAP="${BASH_REMATCH[1]}"
     fi
+
+    trap '_typo_bash_exit_trap' EXIT
 }
 
 _typo_install_fix_binding() {

--- a/internal/cmd/explain.go
+++ b/internal/cmd/explain.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -20,6 +21,10 @@ func cmdExplain(args []string) int {
 	aliasContextFile := fs.String("alias-context", "", "file containing shell correction context")
 
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return 1
 	}
 

--- a/internal/cmd/fix.go
+++ b/internal/cmd/fix.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -33,8 +34,12 @@ type fixOptions struct {
 
 func cmdFix(args []string) int {
 	startedAt := time.Now()
-	opts, ok := parseFixOptions(args)
-	if !ok {
+	opts, err := parseFixOptions(args)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return 1
 	}
 
@@ -67,7 +72,7 @@ func cmdFix(args []string) int {
 	return finishUnfixedCommand(startedAt, cfg, opts, result)
 }
 
-func parseFixOptions(args []string) (fixOptions, bool) {
+func parseFixOptions(args []string) (fixOptions, error) {
 	fs := flag.NewFlagSet("fix", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	stderrFile := fs.String("s", "", "file containing stderr from previous command")
@@ -80,16 +85,14 @@ func parseFixOptions(args []string) (fixOptions, bool) {
 	selectMode := fs.Bool("select", false, "select from configured correction candidates")
 
 	if err := fs.Parse(args); err != nil {
-		return fixOptions{}, false
+		return fixOptions{}, err
 	}
 
 	if fs.NArg() < 1 {
-		fmt.Fprintln(os.Stderr, "Error: command required")
-		return fixOptions{}, false
+		return fixOptions{}, fmt.Errorf("command required")
 	}
 	if *selectMode && (debugMode.enabled() || *traceFile != "") {
-		fmt.Fprintln(os.Stderr, "Error: --select cannot be combined with --debug or --trace-file")
-		return fixOptions{}, false
+		return fixOptions{}, fmt.Errorf("--select cannot be combined with --debug or --trace-file")
 	}
 
 	return fixOptions{
@@ -101,7 +104,7 @@ func parseFixOptions(args []string) (fixOptions, bool) {
 		debugMode:        debugMode,
 		traceFile:        *traceFile,
 		selectMode:       *selectMode,
-	}, true
+	}, nil
 }
 
 func readFixStderr(stderrFile string) string {

--- a/internal/cmd/fix_command_test.go
+++ b/internal/cmd/fix_command_test.go
@@ -207,6 +207,50 @@ func TestExplainCommandOutput(t *testing.T) {
 	}
 }
 
+func TestFixAndExplainFlagErrorsReturnThroughRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantCode   int
+		wantStderr string
+	}{
+		{
+			name:       "fix bad flag",
+			args:       []string{"typo", "fix", "--bogus"},
+			wantCode:   1,
+			wantStderr: "flag provided but not defined",
+		},
+		{
+			name:       "explain bad flag",
+			args:       []string{"typo", "explain", "--bogus"},
+			wantCode:   1,
+			wantStderr: "flag provided but not defined",
+		},
+		{
+			name:     "fix help",
+			args:     []string{"typo", "fix", "--help"},
+			wantCode: 0,
+		},
+		{
+			name:     "explain help",
+			args:     []string{"typo", "explain", "--help"},
+			wantCode: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, _, stderr := runCLI(t, tt.args)
+			if code != tt.wantCode {
+				t.Fatalf("Run() code = %d, want %d; stderr=%q", code, tt.wantCode, stderr)
+			}
+			if tt.wantStderr != "" && !strings.Contains(stderr, tt.wantStderr) {
+				t.Fatalf("stderr missing %q: %q", tt.wantStderr, stderr)
+			}
+		})
+	}
+}
+
 func TestFixCommand(t *testing.T) {
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()

--- a/internal/cmd/shell_integration_uninstall_test.go
+++ b/internal/cmd/shell_integration_uninstall_test.go
@@ -178,6 +178,17 @@ _typo_bashexit
 `)
 }
 
+func TestBashIntegrationPreservesExistingExitTrap(t *testing.T) {
+	output := runBashIntegrationScript(t, `
+trap 'printf "previous-exit-trap\n"' EXIT
+source "$1"
+`)
+
+	if !bytes.Contains(output, []byte("previous-exit-trap")) {
+		t.Fatalf("expected previous EXIT trap to run, got:\n%s", output)
+	}
+}
+
 func TestBashIntegrationFallsBackWhenDirectEscBindingIsNotActive(t *testing.T) {
 	runBashIntegrationScript(t, `
 (( BASH_VERSINFO[0] >= 5 )) || exit 0

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -384,7 +384,30 @@ func normalizeUpdateTarget(target string) (updateMode, string, error) {
 	if strings.HasPrefix(target, "@") {
 		return updateModeMain, "", fmt.Errorf("unsupported --version %q; use 'typo update' for main, or '--version <release>' such as '--version 1.1.0'", target)
 	}
+	if !isReleaseVersionSelector(target) {
+		return updateModeMain, "", fmt.Errorf("invalid --version %q; use '--version <release>' such as '--version 1.1.0'", target)
+	}
 	return updateModeRelease, normalizeVersionTag(target), nil
+}
+
+func isReleaseVersionSelector(target string) bool {
+	target = trimVersionPrefix(target)
+	if target == "" {
+		return false
+	}
+
+	parts := strings.Split(target, ".")
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		for _, r := range part {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func normalizeVersionTag(version string) string {

--- a/internal/cmd/update_test.go
+++ b/internal/cmd/update_test.go
@@ -482,6 +482,28 @@ func TestCmdUpdateRejectsGoStyleLatestVersionBeforeInstallMethod(t *testing.T) {
 	}
 }
 
+func TestCmdUpdateRejectsInvalidReleaseVersionBeforeInstallMethod(t *testing.T) {
+	tmpHome := t.TempDir()
+	typoPath := filepath.Join(tmpHome, "go", "bin", "typo")
+	calls := withUpdateTestHooks(t, typoPath)
+	t.Setenv("GOPATH", filepath.Join(tmpHome, "go"))
+
+	code, _, stderr := captureUpdateOutput(t, func() int {
+		return cmdUpdate([]string{"--version", "abc"})
+	})
+
+	if code == 0 {
+		t.Fatalf("expected invalid release version to fail")
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("invalid release version should not run commands, got %#v", *calls)
+	}
+	if !strings.Contains(stderr, "invalid --version \"abc\"") ||
+		!strings.Contains(stderr, "use '--version <release>' such as '--version 1.1.0'") {
+		t.Fatalf("missing invalid version guidance, got %q", stderr)
+	}
+}
+
 func TestCmdUpdateDryRunDoesNotRunCommand(t *testing.T) {
 	typoPath := filepath.Join(t.TempDir(), ".local", "bin", "typo")
 	calls := withUpdateTestHooks(t, typoPath)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -411,7 +412,10 @@ func applyRuleScopeValue(next *itypes.UserConfig, key, value string) error {
 
 // ValidateUserConfig checks whether the user config matches allowed ranges and known enums.
 func ValidateUserConfig(u itypes.UserConfig) error {
-	if u.SimilarityThreshold < minSimilarityThreshold || u.SimilarityThreshold > maxSimilarityThreshold {
+	if math.IsNaN(u.SimilarityThreshold) ||
+		math.IsInf(u.SimilarityThreshold, 0) ||
+		u.SimilarityThreshold < minSimilarityThreshold ||
+		u.SimilarityThreshold > maxSimilarityThreshold {
 		return fmt.Errorf("similarity_threshold must be between %.1f and %.1f", minSimilarityThreshold, maxSimilarityThreshold)
 	}
 	if u.MaxEditDistance < minMaxEditDistance {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"math"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -145,6 +146,15 @@ func TestDefaultUserConfig(t *testing.T) {
 	}
 	if !cfg.Rules["git"].Enabled {
 		t.Fatal("rules.git.enabled should default to true")
+	}
+}
+
+func TestValidateUserConfigRejectsNonFiniteSimilarityThreshold(t *testing.T) {
+	cfg := DefaultUserConfig()
+	cfg.SimilarityThreshold = math.NaN()
+
+	if err := ValidateUserConfig(cfg); err == nil {
+		t.Fatal("ValidateUserConfig should reject NaN similarity_threshold")
 	}
 }
 


### PR DESCRIPTION
## Summary
- return fix/explain flag parsing errors through Run instead of exiting the process
- reject invalid update release selectors and non-finite similarity thresholds earlier
- preserve existing Bash EXIT traps while keeping shellcheck clean

## Test Plan
- go test ./internal/cmd ./internal/config -run 'TestFixAndExplainFlagErrorsReturnThroughRun|TestBashIntegrationPreservesExistingExitTrap|TestCmdUpdateRejectsInvalidReleaseVersionBeforeInstallMethod|TestValidateUserConfigRejectsNonFiniteSimilarityThreshold' -count=1
- shellcheck tools/scripts/install.sh benchmarks/bench.sh tools/release/update-homebrew-formula.sh install/typo.bash
- bash -n tools/scripts/install.sh benchmarks/bench.sh tools/release/update-homebrew-formula.sh install/typo.bash
- zsh -n install/typo.zsh
- fish -n install/typo.fish
- make ci
- make coverage-check
- make build

Notes: PowerShell checks that require pwsh were skipped by the test suite on this machine because pwsh is not installed; Windows quick-install tests were skipped because this host is not Windows.