### PR TITLE
chore(dev): sync Go version docs and storage coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to Typo! This document outlines the 
 
 ## Prerequisites
 
-- [Go 1.25+](https://golang.org/dl/)
+- [Go 1.26.3](https://golang.org/dl/)
 - [Docker](https://docs.docker.com/get-docker/) (optional, for end-to-end tests)
 - [GNU Make](https://www.gnu.org/software/make/)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center"><strong>Fix mistyped shell commands from the command line.</strong></p>
 
-[![Build Status](https://github.com/yuluo-yx/typo/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/yuluo-yx/typo/actions/workflows/build-and-test.yml) [![Go](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go)](https://golang.org) [![Version](https://img.shields.io/github/v/tag/yuluo-yx/typo)](https://github.com/yuluo-yx/typo/releases) [![License](https://img.shields.io/github/license/yuluo-yx/typo)](LICENSE) [![Stars](https://img.shields.io/github/stars/yuluo-yx/typo)](https://github.com/yuluo-yx/typo)
+[![Build Status](https://github.com/yuluo-yx/typo/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/yuluo-yx/typo/actions/workflows/build-and-test.yml) [![Go](https://img.shields.io/badge/Go-1.26.3-00ADD8?logo=go)](https://golang.org) [![Version](https://img.shields.io/github/v/tag/yuluo-yx/typo)](https://github.com/yuluo-yx/typo/releases) [![License](https://img.shields.io/github/license/yuluo-yx/typo)](LICENSE) [![Stars](https://img.shields.io/github/stars/yuluo-yx/typo)](https://github.com/yuluo-yx/typo)
 
 English | [简体中文](README_CN.md)
 
@@ -136,7 +136,7 @@ See [Command Reference](docs/reference/commands.md) for all subcommands and flag
 
 ## Development
 
-Development requires Go 1.25+ and GNU Make.
+Development requires Go 1.26.3 and GNU Make.
 
 ```bash
 make setup

--- a/README_CN.md
+++ b/README_CN.md
@@ -4,7 +4,7 @@
 
 <p align="center"><strong>在终端里直接修正输错的命令。</strong></p>
 
-[![Build Status](https://github.com/yuluo-yx/typo/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/yuluo-yx/typo/actions/workflows/build-and-test.yml) [![Go](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go)](https://golang.org) [![Version](https://img.shields.io/github/v/tag/yuluo-yx/typo)](https://github.com/yuluo-yx/typo/releases) [![License](https://img.shields.io/github/license/yuluo-yx/typo)](LICENSE) [![Stars](https://img.shields.io/github/stars/yuluo-yx/typo)](https://github.com/yuluo-yx/typo)
+[![Build Status](https://github.com/yuluo-yx/typo/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/yuluo-yx/typo/actions/workflows/build-and-test.yml) [![Go](https://img.shields.io/badge/Go-1.26.3-00ADD8?logo=go)](https://golang.org) [![Version](https://img.shields.io/github/v/tag/yuluo-yx/typo)](https://github.com/yuluo-yx/typo/releases) [![License](https://img.shields.io/github/license/yuluo-yx/typo)](LICENSE) [![Stars](https://img.shields.io/github/stars/yuluo-yx/typo)](https://github.com/yuluo-yx/typo)
 
 [English](README.md) | 简体中文
 
@@ -136,7 +136,7 @@ typo history list
 
 ## 本地开发
 
-开发环境需要 Go 1.25+ 和 GNU Make。
+开发环境需要 Go 1.26.3 和 GNU Make。
 
 ```bash
 make setup

--- a/internal/storage/files.go
+++ b/internal/storage/files.go
@@ -7,11 +7,43 @@ import (
 	"time"
 )
 
+type atomicFile interface {
+	Name() string
+	Chmod(os.FileMode) error
+	Write([]byte) (int, error)
+	Sync() error
+	Close() error
+}
+
+type atomicFileOps interface {
+	createTemp(dir, pattern string) (atomicFile, error)
+	rename(oldpath, newpath string) error
+	remove(name string) error
+}
+
+type osAtomicFileOps struct{}
+
+func (osAtomicFileOps) createTemp(dir, pattern string) (atomicFile, error) {
+	return os.CreateTemp(dir, pattern)
+}
+
+func (osAtomicFileOps) rename(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}
+
+func (osAtomicFileOps) remove(name string) error {
+	return os.Remove(name)
+}
+
 // WriteFileAtomic writes the target file atomically by renaming a temp file in the same directory.
 func WriteFileAtomic(filename string, data []byte, perm os.FileMode) error {
+	return writeFileAtomicWithOps(filename, data, perm, osAtomicFileOps{})
+}
+
+func writeFileAtomicWithOps(filename string, data []byte, perm os.FileMode, ops atomicFileOps) error {
 	dir := filepath.Dir(filename)
 
-	tmpFile, err := os.CreateTemp(dir, filepath.Base(filename)+".tmp-*")
+	tmpFile, err := ops.createTemp(dir, filepath.Base(filename)+".tmp-*")
 	if err != nil {
 		return err
 	}
@@ -20,7 +52,7 @@ func WriteFileAtomic(filename string, data []byte, perm os.FileMode) error {
 	keepTemp := false
 	defer func() {
 		if !keepTemp {
-			_ = os.Remove(tmpName)
+			_ = ops.remove(tmpName)
 		}
 	}()
 
@@ -39,7 +71,7 @@ func WriteFileAtomic(filename string, data []byte, perm os.FileMode) error {
 	if err := tmpFile.Close(); err != nil {
 		return err
 	}
-	if err := os.Rename(tmpName, filename); err != nil {
+	if err := ops.rename(tmpName, filename); err != nil {
 		return err
 	}
 

--- a/internal/storage/files_test.go
+++ b/internal/storage/files_test.go
@@ -81,6 +81,64 @@ func TestWriteFileAtomic_RenameFailure(t *testing.T) {
 	}
 }
 
+func TestWriteFileAtomic_OperationFailuresCleanTempFile(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "data.json")
+
+	tests := []struct {
+		name      string
+		configure func(*fakeAtomicFileOps)
+	}{
+		{
+			name: "chmod",
+			configure: func(ops *fakeAtomicFileOps) {
+				ops.file.chmodErr = errors.New("chmod failed")
+			},
+		},
+		{
+			name: "write",
+			configure: func(ops *fakeAtomicFileOps) {
+				ops.file.writeErr = errors.New("write failed")
+			},
+		},
+		{
+			name: "sync",
+			configure: func(ops *fakeAtomicFileOps) {
+				ops.file.syncErr = errors.New("sync failed")
+			},
+		},
+		{
+			name: "close",
+			configure: func(ops *fakeAtomicFileOps) {
+				ops.file.closeErr = errors.New("close failed")
+			},
+		},
+		{
+			name: "rename",
+			configure: func(ops *fakeAtomicFileOps) {
+				ops.renameErr = errors.New("rename failed")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := &fakeAtomicFileOps{file: &fakeAtomicFile{name: "temp-file"}}
+			tt.configure(ops)
+
+			err := writeFileAtomicWithOps(target, []byte("x"), 0600, ops)
+			if err == nil {
+				t.Fatal("expected WriteFileAtomic to return operation failure")
+			}
+			if !strings.Contains(err.Error(), tt.name) {
+				t.Fatalf("expected %s error, got %v", tt.name, err)
+			}
+			if len(ops.removed) != 1 || ops.removed[0] != "temp-file" {
+				t.Fatalf("expected temp file cleanup, got %v", ops.removed)
+			}
+		})
+	}
+}
+
 func TestQuarantineInvalidJSON(t *testing.T) {
 	tmpDir := t.TempDir()
 	target := filepath.Join(tmpDir, "broken.json")
@@ -138,4 +196,54 @@ func captureStderr(t *testing.T, fn func()) string {
 		t.Fatalf("failed to read captured stderr: %v", err)
 	}
 	return string(data)
+}
+
+type fakeAtomicFileOps struct {
+	file      *fakeAtomicFile
+	renameErr error
+	removed   []string
+}
+
+func (ops *fakeAtomicFileOps) createTemp(string, string) (atomicFile, error) {
+	return ops.file, nil
+}
+
+func (ops *fakeAtomicFileOps) rename(string, string) error {
+	return ops.renameErr
+}
+
+func (ops *fakeAtomicFileOps) remove(name string) error {
+	ops.removed = append(ops.removed, name)
+	return nil
+}
+
+type fakeAtomicFile struct {
+	name     string
+	chmodErr error
+	writeErr error
+	syncErr  error
+	closeErr error
+}
+
+func (f *fakeAtomicFile) Name() string {
+	return f.name
+}
+
+func (f *fakeAtomicFile) Chmod(os.FileMode) error {
+	return f.chmodErr
+}
+
+func (f *fakeAtomicFile) Write(data []byte) (int, error) {
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+	return len(data), nil
+}
+
+func (f *fakeAtomicFile) Sync() error {
+	return f.syncErr
+}
+
+func (f *fakeAtomicFile) Close() error {
+	return f.closeErr
 }


### PR DESCRIPTION
## Summary
- Sync README, README_CN, and CONTRIBUTING Go version requirements with go.mod's 1.26.3 declaration.
- Add a small internal file-operation injection layer for atomic storage writes while preserving the public WriteFileAtomic API.
- Cover chmod, write, sync, close, and rename failure cleanup paths in internal/storage tests.

## Test Plan
- go test ./...
- go test ./internal/... -cover
- pre-commit hook suite during git commit