### PR TITLE
chore(dev): tighten fmt scope and storage durability

### DIFF
--- a/internal/storage/dirsync_unix.go
+++ b/internal/storage/dirsync_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package storage
+
+import "os"
+
+func (osAtomicFileOps) syncDir(dir string) error {
+	dirFile, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	if err := dirFile.Sync(); err != nil {
+		_ = dirFile.Close()
+		return err
+	}
+	return dirFile.Close()
+}

--- a/internal/storage/dirsync_windows.go
+++ b/internal/storage/dirsync_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package storage
+
+func (osAtomicFileOps) syncDir(string) error {
+	return nil
+}

--- a/internal/storage/files.go
+++ b/internal/storage/files.go
@@ -19,6 +19,7 @@ type atomicFileOps interface {
 	createTemp(dir, pattern string) (atomicFile, error)
 	rename(oldpath, newpath string) error
 	remove(name string) error
+	syncDir(dir string) error
 }
 
 type osAtomicFileOps struct{}
@@ -76,6 +77,9 @@ func writeFileAtomicWithOps(filename string, data []byte, perm os.FileMode, ops 
 	}
 
 	keepTemp = true
+	if err := ops.syncDir(dir); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/storage/files_test.go
+++ b/internal/storage/files_test.go
@@ -139,6 +139,41 @@ func TestWriteFileAtomic_OperationFailuresCleanTempFile(t *testing.T) {
 	}
 }
 
+func TestWriteFileAtomic_SyncsParentDirectoryAfterRename(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "nested", "data.json")
+	ops := &fakeAtomicFileOps{file: &fakeAtomicFile{name: "temp-file"}}
+
+	if err := writeFileAtomicWithOps(target, []byte("x"), 0600, ops); err != nil {
+		t.Fatalf("WriteFileAtomic failed: %v", err)
+	}
+
+	if len(ops.syncedDirs) != 1 || ops.syncedDirs[0] != filepath.Dir(target) {
+		t.Fatalf("expected parent directory sync for %q, got %v", filepath.Dir(target), ops.syncedDirs)
+	}
+	if len(ops.removed) != 0 {
+		t.Fatalf("expected no temp cleanup after successful rename, got %v", ops.removed)
+	}
+}
+
+func TestWriteFileAtomic_ParentDirectorySyncFailure(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "data.json")
+	ops := &fakeAtomicFileOps{
+		file:       &fakeAtomicFile{name: "temp-file"},
+		syncDirErr: errors.New("sync dir failed"),
+	}
+
+	err := writeFileAtomicWithOps(target, []byte("x"), 0600, ops)
+	if err == nil {
+		t.Fatal("expected WriteFileAtomic to fail when parent directory sync fails")
+	}
+	if !strings.Contains(err.Error(), "sync dir") {
+		t.Fatalf("expected parent directory sync error, got %v", err)
+	}
+	if len(ops.removed) != 0 {
+		t.Fatalf("expected no temp cleanup after successful rename, got %v", ops.removed)
+	}
+}
+
 func TestQuarantineInvalidJSON(t *testing.T) {
 	tmpDir := t.TempDir()
 	target := filepath.Join(tmpDir, "broken.json")
@@ -199,9 +234,11 @@ func captureStderr(t *testing.T, fn func()) string {
 }
 
 type fakeAtomicFileOps struct {
-	file      *fakeAtomicFile
-	renameErr error
-	removed   []string
+	file       *fakeAtomicFile
+	renameErr  error
+	syncDirErr error
+	removed    []string
+	syncedDirs []string
 }
 
 func (ops *fakeAtomicFileOps) createTemp(string, string) (atomicFile, error) {
@@ -215,6 +252,11 @@ func (ops *fakeAtomicFileOps) rename(string, string) error {
 func (ops *fakeAtomicFileOps) remove(name string) error {
 	ops.removed = append(ops.removed, name)
 	return nil
+}
+
+func (ops *fakeAtomicFileOps) syncDir(dir string) error {
+	ops.syncedDirs = append(ops.syncedDirs, dir)
+	return ops.syncDirErr
 }
 
 type fakeAtomicFile struct {

--- a/tools/make/golang.mk
+++ b/tools/make/golang.mk
@@ -82,13 +82,14 @@ download: ## Download dependencies
 fmt: ## Run go fmt
 	@$(LOG_TARGET)
 	$(GO) fmt ./...
-	gofmt -s -w .
+	@git ls-files '*.go' | while IFS= read -r file; do \
+		gofmt -s -w "$$file"; \
+	done
 
 .PHONY: fmt-check
 fmt-check: ## Check go fmt without modifying files
 	@$(LOG_TARGET)
-	@files="$$(find . -type f -name '*.go' -not -path './.git/*')"; \
-	unformatted="$$(gofmt -s -l $$files)"; \
+	@unformatted="$$(git ls-files '*.go' | while IFS= read -r file; do gofmt -s -l "$$file"; done)"; \
 	if [ -n "$$unformatted" ]; then \
 		echo "$$unformatted"; \
 		echo "go files are not formatted; run make fmt" >&2; \

--- a/tools/scripts/install.sh
+++ b/tools/scripts/install.sh
@@ -318,9 +318,9 @@ main() {
   if [[ -z "$shell" ]]; then
     echo "Warning: Unrecognised shell '${SHELL:-}'. Add 'eval \"\$(typo init <shell>)\"' to your shell config manually." >&2
   elif [[ "$shell" == "fish" ]]; then
-    echo "Please add 'typo init fish | source' to your shell configuration file (e.g., ~/.config/fish/config.fish) to enable shell integration. Not forgotten to source it!"
+    echo "Please add 'typo init fish | source' to your shell configuration file (e.g., ~/.config/fish/config.fish). Restart your shell or source the config file to enable shell integration."
   else
-    echo "Please add 'eval \"\$(typo init ${shell})\"' to your shell configuration file (e.g., ~/.${shell}rc) to enable shell integration. Not forgotten to source it!"
+    echo "Please add 'eval \"\$(typo init ${shell})\"' to your shell configuration file (e.g., ~/.${shell}rc). Restart your shell or source the config file to enable shell integration."
   fi
 }
 


### PR DESCRIPTION
## Summary
- Scope Go formatting checks to tracked Go files so local caches and tool-managed files are ignored.
- Improve the post-install shell integration reminder text in the macOS/Linux installer.
- Sync the parent directory after atomic storage renames on non-Windows platforms, with Windows kept as a no-op for platform compatibility.

## Test Plan
- make fmt-check
- go test ./internal/storage -cover
- go test ./...
- go test ./internal/... -cover
- pre-commit hook suite during git commit