### PR TITLE
chore(ci): add fish coverage and doctor diagnostics

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -68,6 +68,20 @@ body:
       placeholder: e.g. typo 0.2.0, main@abcdef1
     validations:
       required: true
+  - type: textarea
+    id: doctor-json
+    attributes:
+      label: typo doctor --json
+      description: |
+        Run `typo doctor --json` and paste the output. If the command fails, paste the error instead.
+        Redact local paths, usernames, or environment details you do not want to share.
+      placeholder: |
+        {
+          "schema_version": 1,
+          "ok": false,
+          "checks": []
+        }
+      render: json
   - type: input
     id: go-version
     attributes:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -62,6 +62,22 @@ jobs:
       - run: make build-e2e-image
       - run: make test-e2e-docker
 
+  e2e-fish:
+    name: E2E fish
+    runs-on: ubuntu-latest
+    if: github.repository == 'yuluo-yx/typo'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./tools/github-setup-deps
+      - name: Install fish
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y fish
+      - name: Verify fish
+        run: fish --version
+      - name: Run fish e2e tests
+        run: go test ./e2e -v -run 'TestE2E(Fish(Integration|Inventory)|DoctorDetectsFishHints)'
+
   e2e-host:
     name: E2E ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -231,6 +231,108 @@ human-readable command. The `shell.stderr_cache_supported` field indicates
 whether the current shell integration can pass real stderr cache files to
 `typo fix -s`; fish currently reports `false`.
 
+Example output:
+
+```json
+{
+  "schema_version": 1,
+  "ok": false,
+  "checks": [
+    {
+      "id": "config_directory",
+      "name": "config directory",
+      "status": "pass",
+      "message": "/Users/alice/.typo",
+      "path": "/Users/alice/.typo"
+    },
+    {
+      "id": "config_file",
+      "name": "config file",
+      "status": "pass",
+      "message": "/Users/alice/.typo/config.json",
+      "path": "/Users/alice/.typo/config.json"
+    },
+    {
+      "id": "typo_command",
+      "name": "typo command",
+      "status": "pass",
+      "message": "available in PATH",
+      "path": "/opt/homebrew/bin/typo"
+    },
+    {
+      "id": "shell_integration",
+      "name": "shell integration",
+      "status": "fail",
+      "message": "not loaded"
+    },
+    {
+      "id": "install_method",
+      "name": "install method",
+      "status": "pass",
+      "message": "Homebrew",
+      "path": "/opt/homebrew/bin/typo"
+    },
+    {
+      "id": "go_bin_path",
+      "name": "Go bin PATH",
+      "status": "skip",
+      "message": "not a go install binary"
+    }
+  ],
+  "shell": {
+    "name": "fish",
+    "config_file": "~/.config/fish/config.fish",
+    "init_command": "typo init fish | source",
+    "reload_command": "source ~/.config/fish/config.fish",
+    "integration_loaded": false,
+    "stderr_cache_supported": false,
+    "alias_context_supported": true,
+    "environment_context_supported": true
+  },
+  "config": {
+    "dir": "/Users/alice/.typo",
+    "dir_exists": true,
+    "file": "/Users/alice/.typo/config.json",
+    "file_exists": true,
+    "settings": [
+      {
+        "key": "similarity-threshold",
+        "value": "0.72"
+      },
+      {
+        "key": "max-edit-distance",
+        "value": "2"
+      },
+      {
+        "key": "history.enabled",
+        "value": "true"
+      }
+    ]
+  },
+  "install": {
+    "method": "Homebrew",
+    "detail": "/opt/homebrew/bin",
+    "path": "/opt/homebrew/bin/typo",
+    "action": "brew update && brew upgrade typo",
+    "update_supported": true
+  },
+  "go_bin_path": {
+    "dir": "/Users/alice/go/bin",
+    "typo_in_go_bin": false,
+    "configured": false
+  },
+  "actions": [
+    {
+      "id": "enable_shell_integration",
+      "command": "typo init fish | source"
+    }
+  ]
+}
+```
+
+The JSON may include local paths from your machine. Redact user names or paths
+before posting it publicly if they are sensitive.
+
 ## `typo version`
 
 Print the current version, commit, and build date when available.

--- a/docs/reference/commands_CN.md
+++ b/docs/reference/commands_CN.md
@@ -226,6 +226,107 @@ typo doctor --json
 命令相同的退出码语义。`shell.stderr_cache_supported` 字段表示当前 shell 集成是否
 可以把真实 stderr 缓存文件传给 `typo fix -s`；fish 当前会报告 `false`。
 
+示例输出：
+
+```json
+{
+  "schema_version": 1,
+  "ok": false,
+  "checks": [
+    {
+      "id": "config_directory",
+      "name": "config directory",
+      "status": "pass",
+      "message": "/Users/alice/.typo",
+      "path": "/Users/alice/.typo"
+    },
+    {
+      "id": "config_file",
+      "name": "config file",
+      "status": "pass",
+      "message": "/Users/alice/.typo/config.json",
+      "path": "/Users/alice/.typo/config.json"
+    },
+    {
+      "id": "typo_command",
+      "name": "typo command",
+      "status": "pass",
+      "message": "available in PATH",
+      "path": "/opt/homebrew/bin/typo"
+    },
+    {
+      "id": "shell_integration",
+      "name": "shell integration",
+      "status": "fail",
+      "message": "not loaded"
+    },
+    {
+      "id": "install_method",
+      "name": "install method",
+      "status": "pass",
+      "message": "Homebrew",
+      "path": "/opt/homebrew/bin/typo"
+    },
+    {
+      "id": "go_bin_path",
+      "name": "Go bin PATH",
+      "status": "skip",
+      "message": "not a go install binary"
+    }
+  ],
+  "shell": {
+    "name": "fish",
+    "config_file": "~/.config/fish/config.fish",
+    "init_command": "typo init fish | source",
+    "reload_command": "source ~/.config/fish/config.fish",
+    "integration_loaded": false,
+    "stderr_cache_supported": false,
+    "alias_context_supported": true,
+    "environment_context_supported": true
+  },
+  "config": {
+    "dir": "/Users/alice/.typo",
+    "dir_exists": true,
+    "file": "/Users/alice/.typo/config.json",
+    "file_exists": true,
+    "settings": [
+      {
+        "key": "similarity-threshold",
+        "value": "0.72"
+      },
+      {
+        "key": "max-edit-distance",
+        "value": "2"
+      },
+      {
+        "key": "history.enabled",
+        "value": "true"
+      }
+    ]
+  },
+  "install": {
+    "method": "Homebrew",
+    "detail": "/opt/homebrew/bin",
+    "path": "/opt/homebrew/bin/typo",
+    "action": "brew update && brew upgrade typo",
+    "update_supported": true
+  },
+  "go_bin_path": {
+    "dir": "/Users/alice/go/bin",
+    "typo_in_go_bin": false,
+    "configured": false
+  },
+  "actions": [
+    {
+      "id": "enable_shell_integration",
+      "command": "typo init fish | source"
+    }
+  ]
+}
+```
+
+JSON 中可能包含本机路径。公开提交 issue 前，如有需要请脱敏用户名或路径。
+
 ## `typo version`
 
 输出当前版本、commit 和构建时间（如果可用）。

--- a/tools/github-setup-deps/action.yml
+++ b/tools/github-setup-deps/action.yml
@@ -6,9 +6,9 @@ runs:
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
-    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.13'
-    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '22'


### PR DESCRIPTION
## Summary
- Add a dedicated Ubuntu fish E2E job that installs fish and runs fish integration, inventory, and doctor hint coverage.
- Bump shared GitHub setup action dependencies to setup-python v6.2.0 and setup-node v6.4.0 with pinned SHAs.
- Document complete typo doctor --json examples in English and Chinese command references, and add a bug report field for the JSON output.

## Test Plan
- [x] git diff --check
- [x] fish --version
- [x] pre-commit run --files .github/workflows/build-and-test.yml .github/ISSUE_TEMPLATE/bug_report.yml tools/github-setup-deps/action.yml docs/reference/commands.md docs/reference/commands_CN.md
- [x] go test ./internal/cmd -count=1 -run TestDoctorJSON -v
- [x] go test ./e2e -count=1 -run "TestE2E(Fish(Integration|Inventory)|DoctorDetectsFishHints)" -v