### PR TITLE
fix(engine): harden correction and persistence behavior

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -20,7 +20,7 @@ jobs:
   test:
     name: Homebrew ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    # Dependabot 不维护 Homebrew formula；即使未来路径过滤扩大，也不在依赖 PR 中执行 brew。
+    # Dependabot does not maintain the Homebrew formula, so dependency PRs must not run brew even if path filters expand later.
     if: >-
       github.repository == 'yuluo-yx/typo' &&
       (github.event_name != 'pull_request' || github.actor != 'dependabot[bot]')

--- a/benchmarks/benchmark_test.go
+++ b/benchmarks/benchmark_test.go
@@ -30,45 +30,52 @@ func BenchmarkTypoCLI(b *testing.B) {
 		name         string
 		args         []string
 		expectedCode int
+		expectedOut  string
 	}{
 		{
 			name:         "fix-rule-match",
-			args:         []string{"fix", "gut status"},
+			args:         []string{"fix", "--no-history", "gut status"},
 			expectedCode: 0,
+			expectedOut:  "git status\n",
 		},
 		{
 			name:         "fix-distance-match",
-			args:         []string{"fix", "dkcer ps"},
+			args:         []string{"fix", "--no-history", "dkcer ps"},
 			expectedCode: 0,
+			expectedOut:  "docker ps\n",
 		},
 		{
 			name:         "fix-compound-multi-match",
-			args:         []string{"fix", "gti stauts && dcoker ps"},
+			args:         []string{"fix", "--no-history", "gti stauts && dcoker ps"},
 			expectedCode: 0,
+			expectedOut:  "git status && docker ps\n",
 		},
 		{
 			name:         "fix-pipeline-compound-match",
-			args:         []string{"fix", "gut status | grep main && dcoker ps"},
+			args:         []string{"fix", "--no-history", "gut status | grep main && dcoker ps"},
 			expectedCode: 0,
+			expectedOut:  "git status | grep main && docker ps\n",
 		},
 		{
 			name:         "fix-wrapper-subcommand-match",
-			args:         []string{"fix", "sudo git -C repo stauts || dcoker ps"},
+			args:         []string{"fix", "--no-history", "sudo git -C repo stauts || dcoker ps"},
 			expectedCode: 0,
+			expectedOut:  "sudo git -C repo status || docker ps\n",
 		},
 		{
 			name:         "fix-parser-compound-match",
-			args:         []string{"fix", "-s", env.gitStderr, "sudo git remove -v && dcoker ps"},
+			args:         []string{"fix", "--no-history", "-s", env.gitStderr, "sudo git remove -v && dcoker ps"},
 			expectedCode: 0,
+			expectedOut:  "sudo git remote -v && docker ps\n",
 		},
 		{
 			name:         "fix-no-match",
-			args:         []string{"fix", "xyzabc"},
+			args:         []string{"fix", "--no-history", "xyzabc"},
 			expectedCode: 1,
 		},
 		{
 			name:         "fix-noop-compound",
-			args:         []string{"fix", "git status && echo ok"},
+			args:         []string{"fix", "--no-history", "git status && echo ok"},
 			expectedCode: 1,
 		},
 		{
@@ -85,11 +92,39 @@ func BenchmarkTypoCLI(b *testing.B) {
 
 	for _, tt := range benchmarks {
 		b.Run(tt.name, func(b *testing.B) {
+			env.validate(b, tt.expectedCode, tt.expectedOut, tt.args...)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				env.run(b, tt.expectedCode, tt.args...)
 			}
 		})
+	}
+}
+
+func (e *cliBenchmarkEnv) validate(b *testing.B, expectedCode int, expectedOut string, args ...string) {
+	b.Helper()
+
+	cmd := exec.Command(e.binary, args...)
+	cmd.Dir = e.root
+	cmd.Env = e.commandEnv()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	code, err := runBenchmarkCommand(cmd)
+	if err != nil {
+		b.Fatalf("failed to validate benchmark command: %v", err)
+	}
+	if code != expectedCode || (expectedOut != "" && stdout.String() != expectedOut) {
+		b.Fatalf(
+			"invalid benchmark case %q: code=%d want=%d stdout=%q want=%q stderr=%q",
+			strings.Join(args, " "),
+			code,
+			expectedCode,
+			stdout.String(),
+			expectedOut,
+			stderr.String(),
+		)
 	}
 }
 
@@ -235,15 +270,9 @@ func (e *cliBenchmarkEnv) run(b *testing.B, expectedCode int, args ...string) {
 	cmd.Stdout = io.Discard
 	cmd.Stderr = io.Discard
 
-	err := cmd.Run()
-	code := 0
+	code, err := runBenchmarkCommand(cmd)
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			code = exitErr.ExitCode()
-		} else {
-			b.Fatalf("failed to execute benchmark command: %v", err)
-		}
+		b.Fatalf("failed to execute benchmark command: %v", err)
 	}
 
 	if code == expectedCode {
@@ -267,4 +296,17 @@ func (e *cliBenchmarkEnv) run(b *testing.B, expectedCode int, args ...string) {
 		stdout.String(),
 		stderr.String(),
 	)
+}
+
+func runBenchmarkCommand(cmd *exec.Cmd) (int, error) {
+	err := cmd.Run()
+	if err == nil {
+		return 0, nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode(), nil
+	}
+	return 0, err
 }

--- a/config.example.jsonc
+++ b/config.example.jsonc
@@ -1,39 +1,39 @@
 {
-  // 匹配候选命令时要求的最低相似度，范围为 0.0 到 1.0。
+  // Minimum similarity required when matching candidate commands, in the range 0.0 to 1.0.
   "similarity_threshold": 0.6,
 
-  // 单个命令词允许的最大编辑距离，值越大匹配越宽松。
+  // Maximum edit distance allowed for one command word; larger values permit broader matches.
   "max_edit_distance": 2,
 
-  // 一次修正流程最多执行的轮数，用于防止循环修正。
+  // Maximum number of passes in one correction flow, used to prevent correction cycles.
   "max_fix_passes": 32,
 
-  // 同一修正被接受多少次后自动学习为用户规则；设为 0 可关闭自动学习。
+  // Number of accepted corrections before auto-learning a user rule; set to 0 to disable auto-learning.
   "auto_learn_threshold": 3,
 
-  // 键盘布局会影响相邻按键的编辑距离权重，可选值：qwerty、dvorak、colemak。
+  // Keyboard layout affects adjacent-key edit weights. Supported values: qwerty, dvorak, and colemak.
   "keyboard": "qwerty",
 
-  // 是否记录修正历史，用于后续排序和自动学习。
+  // Whether to record correction history for later ranking and auto-learning.
   "history": {
     "enabled": true
   },
 
-  // 是否在交互式修正中展示多个候选项，以及候选项数量上限。
+  // Whether to show multiple candidates during interactive correction and their maximum count.
   "candidates": {
     "enabled": false,
     "limit": 3
   },
 
-  // 实验性功能默认关闭，升级时应按发布说明确认行为变化。
+  // Experimental features are disabled by default; review release notes before enabling them after upgrades.
   "experimental": {
-    // 是否启用长选项修正，例如将 --verison 修正为 --version。
+    // Whether to enable long-option correction, such as correcting --verison to --version.
     "long_option_correction": {
       "enabled": false
     }
   },
 
-  // 内置规则作用域开关；关闭某个作用域后，对应工具的内置纠正规则不再生效。
+  // Built-in rule scope toggles; disabling a scope stops its tool-specific built-in correction rules.
   "rules": {
     "brew": {
       "enabled": true

--- a/docs/example/use.md
+++ b/docs/example/use.md
@@ -68,24 +68,19 @@ zsh: command not found: grpe <Enter, Esc, Esc>
 cat ~/.zshrc | grep "zsh"
 ```
 
-## `git pull --set-upstream`
+## `git push --set-upstream`
 
-Have you ever run into this kind of issue when using `git pull`?
+On the first push of a local branch, Git provides the exact command needed to set its upstream:
 
 ```shell
-$ git pull
-There is no tracking information for the current branch.
-Please specify which branch you want to rebase against.
-See git-pull(1) for details.
+$ git push
+fatal: The current branch feature/topic has no upstream branch.
+To push the current branch and set the remote as upstream, use
 
-    git pull <remote> <branch>
-
-If you wish to set tracking information for this branch you can do so with:
-
-    git branch --set-upstream-to=origin/<branch> 0322-yuluo/inprove-add-check
+    git push --set-upstream origin feature/topic
 ```
 
-Press `Esc` `Esc`, and Typo can add the suggested upstream automatically.
+Press `Esc` `Esc`. Typo applies Git's concrete suggestion when the remote and branch names are safe across every supported shell; otherwise it leaves the command unchanged.
 
 ## `git pull --rebase`
 
@@ -102,25 +97,6 @@ Press `Esc` `Esc`, and Typo can retry the same pull with a command-level rebase 
 
 ```shell
 git pull --rebase
-```
-
-## `git push` rejected, pull first
-
-When the remote has commits that are missing locally, Git rejects the push:
-
-```shell
-$ git push origin main
- ! [rejected]        main -> main (fetch first)
-error: failed to push some refs to 'github.com:yuluo-yx/typo.git'
-hint: Updates were rejected because the remote contains work that you do
-hint: not have locally. You may want to first integrate the remote changes
-hint: (e.g., 'git pull ...') before pushing again.
-```
-
-Press `Esc` `Esc`, and Typo can retry the matching pull command first.
-
-```shell
-git pull origin main
 ```
 
 ## No permission? Use `sudo`

--- a/docs/example/use_CN.md
+++ b/docs/example/use_CN.md
@@ -68,24 +68,19 @@ zsh: command not found: grpe <Enter, Esc, Esc>
 cat ~/.zshrc | grep "zsh"
 ```
 
-## `git pull --set-upstream`
+## `git push --set-upstream`
 
-你是否遇到过这类 `git pull` 报错？
+首次推送本地分支时，Git 会给出设置 upstream 的准确命令：
 
 ```shell
-$ git pull
-There is no tracking information for the current branch.
-Please specify which branch you want to rebase against.
-See git-pull(1) for details.
+$ git push
+fatal: The current branch feature/topic has no upstream branch.
+To push the current branch and set the remote as upstream, use
 
-    git pull <remote> <branch>
-
-If you wish to set tracking information for this branch you can do so with:
-
-    git branch --set-upstream-to=origin/<branch> 0322-yuluo/inprove-add-check
+    git push --set-upstream origin feature/topic
 ```
 
-这时按两次 `Esc`，Typo 会自动补全建议的 upstream 设置。
+按两次 `Esc`，当远端名和分支名可在所有支持的 Shell 中安全表示时，Typo 会采用 Git 给出的具体建议；否则保持原命令不变。
 
 ## `git pull --rebase`
 
@@ -102,25 +97,6 @@ fatal: Need to specify how to reconcile divergent branches.
 
 ```shell
 git pull --rebase
-```
-
-## `git push` 被拒绝，先执行 pull
-
-当远端存在本地没有的提交时，Git 会拒绝继续 push：
-
-```shell
-$ git push origin main
- ! [rejected]        main -> main (fetch first)
-error: failed to push some refs to 'github.com:yuluo-yx/typo.git'
-hint: Updates were rejected because the remote contains work that you do
-hint: not have locally. You may want to first integrate the remote changes
-hint: (e.g., 'git pull ...') before pushing again.
-```
-
-这时按两次 `Esc`，Typo 会先重试对应的 pull 命令。
-
-```shell
-git pull origin main
 ```
 
 ## 没有权限？自动补 `sudo`

--- a/docs/reference/how-it-works.md
+++ b/docs/reference/how-it-works.md
@@ -63,7 +63,7 @@ Typo can extract suggestions from real `stderr` output when available.
 
 Currently documented parser coverage:
 
-- `git`: `did you mean...`, missing upstream, divergent pull rebase, and related suggestions
+- `git`: `did you mean...`, explicit push upstream hints, divergent pull rebase, and related suggestions
 - `docker`: unknown command suggestions
 - `npm`: command-not-found suggestions
 
@@ -75,7 +75,7 @@ Examples:
 
 ```bash
 typo fix -s git.stderr "git remove -v"
-typo fix -s git.stderr "git pull"
+typo fix -s git.stderr "git push"
 typo fix -s docker.stderr "docker psa"
 typo fix -s npm.stderr "npm isntall react"
 ```

--- a/docs/reference/how-it-works_CN.md
+++ b/docs/reference/how-it-works_CN.md
@@ -56,7 +56,7 @@ cd $HOME/project
 
 当前已有文档覆盖的解析器包括：
 
-- `git`：`did you mean...`、缺少 upstream、分叉 pull rebase 等建议
+- `git`：`did you mean...`、明确的 push upstream 建议、分叉 pull rebase 等建议
 - `docker`：未知命令建议
 - `npm`：命令未找到建议
 
@@ -68,7 +68,7 @@ fish 集成支持当前缓冲区修正，以及空缓冲区时结合上一条历
 
 ```bash
 typo fix -s git.stderr "git remove -v"
-typo fix -s git.stderr "git pull"
+typo fix -s git.stderr "git push"
 typo fix -s docker.stderr "docker psa"
 typo fix -s npm.stderr "npm isntall react"
 ```

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -686,7 +686,7 @@ func TestE2EReadmeExamples(t *testing.T) {
 
 	gitStderr := env.writeTempFile(t, "git.stderr", "git: 'remove' is not a git command.\n\nThe most similar command is\n\tremote\n")
 	gitPullRebaseStderr := env.writeTempFile(t, "git-pull-rebase.stderr", "hint: You have divergent branches and need to specify how to reconcile them.\nhint: You can do so by running one of the following commands sometime before\nhint: your next pull:\nhint:\nhint:   git config pull.rebase false  # merge\nhint:   git config pull.rebase true   # rebase\nhint:   git config pull.ff only       # fast-forward only\nhint:\nhint: You can replace \"git config\" with \"git config --global\" to set a default\nhint: preference for all repositories. You can also pass --rebase, --no-rebase,\nhint: or --ff-only on the command line to override the configured default per\nhint: invocation.\nfatal: Need to specify how to reconcile divergent branches.\n")
-	gitPushRejectedStderr := env.writeTempFile(t, "git-push-rejected.stderr", "To github.com:yuluo-yx/typo.git\n ! [rejected]        main -> main (fetch first)\nerror: failed to push some refs to 'github.com:yuluo-yx/typo.git'\nhint: Updates were rejected because the remote contains work that you do\nhint: not have locally. You may want to first integrate the remote changes\nhint: (e.g., 'git pull ...') before pushing again.\n")
+	gitPushNoUpstreamStderr := env.writeTempFile(t, "git-push-no-upstream.stderr", "fatal: The current branch feature/topic has no upstream branch.\nTo push the current branch and set the remote as upstream, use\n\n    git push --set-upstream origin feature/topic\n")
 	dockerStderr := env.writeTempFile(t, "docker.stderr", "unknown command: imagesa\n\nDid you mean: images?")
 	npmStderr := env.writeTempFile(t, "npm.stderr", "npm ERR! Did you mean list?")
 	permissionStderr := env.writeTempFile(t, "permission.stderr", "mkdir: 1: Permission denied\n")
@@ -699,7 +699,7 @@ func TestE2EReadmeExamples(t *testing.T) {
 	}{
 		{name: "git stderr parser", command: "git remove -v", stderrFile: gitStderr, want: "git remote -v\n"},
 		{name: "git pull rebase stderr parser", command: "git pull", stderrFile: gitPullRebaseStderr, want: "git pull --rebase\n"},
-		{name: "git push rejected stderr parser", command: "git push origin main", stderrFile: gitPushRejectedStderr, want: "git pull origin main\n"},
+		{name: "git push no upstream stderr parser", command: "git push", stderrFile: gitPushNoUpstreamStderr, want: "git push --set-upstream origin feature/topic\n"},
 		{name: "docker stderr parser", command: "docker imagesa", stderrFile: dockerStderr, want: "docker images\n"},
 		{name: "npm stderr parser", command: "npm ist --depth=0", stderrFile: npmStderr, want: "npm list --depth=0\n"},
 		{name: "permission stderr parser", command: "mkdir 1", stderrFile: permissionStderr, want: "sudo mkdir 1\n"},
@@ -1389,7 +1389,7 @@ func TestE2EFishIntegrationAliasContext(t *testing.T) {
 	initScript := env.initFishScript(t)
 
 	result := env.runFish(t, initScript, `
-set -g TYPO_TEST_BUFFER "k lgo && ktf valdiate"
+set -g TYPO_TEST_BUFFER "k lgo && ktf valdiate && gr stauts"
 
 function commandline
     switch "$argv[1]"
@@ -1406,14 +1406,15 @@ end
 
 source "$argv[1]"
 abbr -a k kubectl
+abbr -a gr "git -C repo"
 function ktf
     terraform $argv
 end
 _typo_fix_command
-test "$TYPO_TEST_BUFFER" = "k logs && ktf validate"; or begin; printf "%s\n" "$TYPO_TEST_BUFFER"; exit 94; end
+test "$TYPO_TEST_BUFFER" = "k logs && ktf validate && gr status"; or begin; printf "%s\n" "$TYPO_TEST_BUFFER"; exit 94; end
 printf "%s\n" "$TYPO_TEST_BUFFER"
 `)
-	if result.code != 0 || !strings.Contains(result.stdout, "k logs && ktf validate") {
+	if result.code != 0 || !strings.Contains(result.stdout, "k logs && ktf validate && gr status") {
 		t.Fatalf("fish alias context fix failed: stdout=%q stderr=%q code=%d", result.stdout, result.stderr, result.code)
 	}
 }

--- a/install/typo.bash
+++ b/install/typo.bash
@@ -410,7 +410,7 @@ _typo_write_alias_context() {
     _typo_append_env_context
 }
 
-# 为 Bash 3.2 查找空闲的单数字文件描述符，避免覆盖用户已打开的描述符。
+# Find an available single-digit file descriptor for Bash 3.2 without overwriting descriptors opened by the user.
 _typo_find_available_fd() {
     local fd=3
 

--- a/install/typo.bash
+++ b/install/typo.bash
@@ -276,10 +276,6 @@ _typo_collect_command_words() {
                                 idx=$((idx + 1))
                                 continue
                                 ;;
-                            --argv0=*|--chdir=*|--default-signal=*|--ignore-signal=*|--block-signal=*|--signal=*|--unset=*|--split-string=*)
-                                idx=$((idx + 1))
-                                continue
-                                ;;
                             --argv0|--chdir|--default-signal|--ignore-signal|--block-signal|--signal|--unset|--split-string|-C|-S|-u)
                                 expect_value=1
                                 idx=$((idx + 1))
@@ -310,7 +306,7 @@ _typo_collect_command_words() {
                                 idx=$((idx + 1))
                                 continue
                                 ;;
-                            --close-from|--group|--host|--other-user|--preserve-env|--prompt|--role|--user|--chdir|-C|-g|-h|-p|-R|-r|-T|-u)
+                            --close-from|--group|--host|--other-user|--prompt|--role|--user|--chdir|-C|-g|-h|-p|-R|-r|-T|-u)
                                 expect_value=1
                                 idx=$((idx + 1))
                                 continue
@@ -414,9 +410,25 @@ _typo_write_alias_context() {
     _typo_append_env_context
 }
 
+# 为 Bash 3.2 查找空闲的单数字文件描述符，避免覆盖用户已打开的描述符。
+_typo_find_available_fd() {
+    local fd=3
+
+    while (( fd <= 9 )); do
+        if ! (eval ": >&$fd") 2>/dev/null; then
+            printf '%s\n' "$fd"
+            return 0
+        fi
+        fd=$((fd + 1))
+    done
+
+    return 1
+}
+
 # Save the original stderr once to avoid chaining shell descriptors.
 _typo_save_original_stderr() {
     local shell_id
+    local available_fd
 
     shell_id="$(_typo_current_shell_id)"
 
@@ -426,21 +438,22 @@ _typo_save_original_stderr() {
     fi
 
     if ! _typo_owns_original_stderr_fd; then
-        exec 3>&2
-        TYPO_ORIG_STDERR_FD=3
+        available_fd="$(_typo_find_available_fd)" || return 1
+        eval "exec ${available_fd}>&2" || return 1
+        TYPO_ORIG_STDERR_FD="$available_fd"
         TYPO_ORIG_STDERR_FD_OWNER="$shell_id"
     fi
 }
 
 _typo_restore_stderr() {
     if _typo_owns_original_stderr_fd; then
-        exec 2>&3
+        exec 2>&"$TYPO_ORIG_STDERR_FD"
     fi
 }
 
 _typo_preexec() {
     _typo_init_stderr_cache || return
-    _typo_save_original_stderr
+    _typo_save_original_stderr || return
     : > "$TYPO_STDERR_CACHE"
     # Use named pipe (FIFO) for reliable stderr capture in bash 4.x.
     # Process substitution (>(...)) in bash 4.x has a known issue where the shell
@@ -452,7 +465,7 @@ _typo_preexec() {
     # 3. In precmd, close stderr->FIFO (tee gets EOF) and wait for tee to finish
     if [[ -n "${_TYPO_STDERR_FIFO:-}" && -p "${_TYPO_STDERR_FIFO:-}" ]]; then
         # Start tee in background, reading from FIFO
-        tee "$TYPO_STDERR_CACHE" >&3 < "$_TYPO_STDERR_FIFO" &
+        tee "$TYPO_STDERR_CACHE" >&"$TYPO_ORIG_STDERR_FD" < "$_TYPO_STDERR_FIFO" &
         _TYPO_TEE_PID=$!
                # Now redirect stderr to the FIFO (this unblocks tee)
         exec 2> "$_TYPO_STDERR_FIFO"
@@ -484,7 +497,7 @@ _typo_bashexit() {
     _typo_restore_stderr
 
     if _typo_owns_original_stderr_fd; then
-        exec 3>&-
+        eval "exec ${TYPO_ORIG_STDERR_FD}>&-"
     fi
     unset TYPO_ORIG_STDERR_FD
     unset TYPO_ORIG_STDERR_FD_OWNER

--- a/install/typo.fish
+++ b/install/typo.fish
@@ -136,7 +136,8 @@ function _typo_write_alias_context
 
     if type -q abbr
         for line in (abbr --show 2>/dev/null)
-            set -l fields (string split ' ' -- "$line")
+            set -l fields
+            printf '%s\n' "$line" | read --tokenize --array fields
             set -l marker_index (contains -i -- -- $fields)
             if test -z "$marker_index"
                 continue
@@ -147,7 +148,7 @@ function _typo_write_alias_context
                 continue
             end
             set -l name "$fields[$name_index]"
-            set -l expansion (string join ' ' $fields[$expansion_index..-1])
+            set -l expansion (string join ' ' -- $fields[$expansion_index..-1])
             if test -n "$name"; and test -n "$expansion"
                 printf 'fish\tabbr\t%s\t%s\n' "$name" "$expansion" >> "$TYPO_ALIAS_CONTEXT"
             end

--- a/install/typo.zsh
+++ b/install/typo.zsh
@@ -253,10 +253,6 @@ _typo_collect_command_words() {
                                 (( idx++ ))
                                 continue
                                 ;;
-                            --argv0=*|--chdir=*|--default-signal=*|--ignore-signal=*|--block-signal=*|--signal=*|--unset=*|--split-string=*)
-                                (( idx++ ))
-                                continue
-                                ;;
                             --argv0|--chdir|--default-signal|--ignore-signal|--block-signal|--signal|--unset|--split-string|-C|-S|-u)
                                 expect_value=1
                                 (( idx++ ))
@@ -287,7 +283,7 @@ _typo_collect_command_words() {
                                 (( idx++ ))
                                 continue
                                 ;;
-                            --close-from|--group|--host|--other-user|--preserve-env|--prompt|--role|--user|--chdir|-C|-g|-h|-p|-R|-r|-T|-u)
+                            --close-from|--group|--host|--other-user|--prompt|--role|--user|--chdir|-C|-g|-h|-p|-R|-r|-T|-u)
                                 expect_value=1
                                 (( idx++ ))
                                 continue

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -24,12 +25,20 @@ func cmdConfig(args []string) int {
 func runConfigSubcommand(cfg *config.Config, args []string) int {
 	switch args[0] {
 	case "list":
+		if len(args) != 1 {
+			fmt.Fprintln(os.Stderr, "Error: config list does not accept arguments")
+			return 1
+		}
 		return cmdConfigList(cfg)
 	case "get":
 		return cmdConfigGet(cfg, args)
 	case "set":
 		return cmdConfigSet(cfg, args)
 	case "reset":
+		if len(args) != 1 {
+			fmt.Fprintln(os.Stderr, "Error: config reset does not accept arguments")
+			return 1
+		}
 		return cmdConfigReset(cfg)
 	case "gen":
 		return cmdConfigGen(cfg, args)
@@ -40,6 +49,10 @@ func runConfigSubcommand(cfg *config.Config, args []string) int {
 }
 
 func cmdConfigList(cfg *config.Config) int {
+	if err := requireLoadedConfig(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
 	for _, setting := range cfg.ListSettings() {
 		fmt.Printf("%s=%s\n", setting.Key, setting.Value)
 	}
@@ -49,6 +62,14 @@ func cmdConfigList(cfg *config.Config) int {
 func cmdConfigGet(cfg *config.Config, args []string) int {
 	if len(args) < 2 {
 		fmt.Fprintln(os.Stderr, "Error: <key> required")
+		return 1
+	}
+	if len(args) != 2 {
+		fmt.Fprintln(os.Stderr, "Error: config get requires exactly <key>")
+		return 1
+	}
+	if err := requireLoadedConfig(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return 1
 	}
 
@@ -67,6 +88,14 @@ func cmdConfigSet(cfg *config.Config, args []string) int {
 		fmt.Fprintln(os.Stderr, "Error: <key> and <value> required")
 		return 1
 	}
+	if len(args) != 3 {
+		fmt.Fprintln(os.Stderr, "Error: config set requires exactly <key> and <value>")
+		return 1
+	}
+	if err := requireLoadedConfig(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
 
 	if err := cfg.Set(args[1], args[2]); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -78,6 +107,10 @@ func cmdConfigSet(cfg *config.Config, args []string) int {
 }
 
 func cmdConfigReset(cfg *config.Config) int {
+	if err := requireConfigDirectory(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
 	if err := cfg.Reset(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return 1
@@ -98,6 +131,10 @@ func cmdConfigGen(cfg *config.Config, args []string) int {
 		fmt.Fprintln(os.Stderr, "Error: config gen does not accept positional arguments")
 		return 1
 	}
+	if err := requireConfigDirectory(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
 	if err := cfg.Generate(*force); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return 1
@@ -108,8 +145,8 @@ func cmdConfigGen(cfg *config.Config, args []string) int {
 }
 
 func cmdRules(args []string) int {
-	if len(args) < 1 {
-		fmt.Fprintln(os.Stderr, "Error: subcommand required (list, add, remove, enable, disable)")
+	if message := rulesArgsError(args); message != "" {
+		fmt.Fprintln(os.Stderr, message)
 		return 1
 	}
 
@@ -119,8 +156,8 @@ func cmdRules(args []string) int {
 	case "list":
 		return cmdRulesList(cfg)
 	case "add":
-		if len(args) < 3 {
-			fmt.Fprintln(os.Stderr, "Error: <from> and <to> required")
+		if err := requireConfigDirectory(cfg); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			return 1
 		}
 		eng := createEngine(cfg)
@@ -131,18 +168,16 @@ func cmdRules(args []string) int {
 		fmt.Printf("Added rule: %s -> %s\n", args[1], args[2])
 		return 0
 	case "remove":
-		if len(args) < 2 {
-			fmt.Fprintln(os.Stderr, "Error: <from> required")
-			return 1
-		}
-		r := engine.NewRules(cfg.ConfigDir)
-		if err := r.RemoveUserRule(args[1]); err != nil {
+		if err := requireConfigDirectory(cfg); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			return 1
 		}
-		h := engine.NewHistory(cfg.ConfigDir)
-		if err := h.RemoveEntriesForCommandWord(args[1]); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: removed rule but failed to clear related history: %v\n", err)
+		eng := engine.NewEngine(
+			engine.WithRules(engine.NewRules(cfg.ConfigDir)),
+			engine.WithHistory(engine.NewHistory(cfg.ConfigDir)),
+		)
+		if err := eng.RemoveRule(args[1]); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			return 1
 		}
 		fmt.Printf("Removed rule: %s\n", args[1])
@@ -157,7 +192,40 @@ func cmdRules(args []string) int {
 	}
 }
 
+func rulesArgsError(args []string) string {
+	if len(args) == 0 {
+		return "Error: subcommand required (list, add, remove, enable, disable)"
+	}
+
+	switch args[0] {
+	case "list":
+		if len(args) != 1 {
+			return "Error: rules list does not accept arguments"
+		}
+	case "add":
+		if len(args) != 3 {
+			return "Error: exactly two arguments required: <from> and <to>"
+		}
+	case "remove":
+		if len(args) != 2 {
+			return "Error: remove requires exactly <from>"
+		}
+	case "enable", "disable":
+		if len(args) != 2 || strings.TrimSpace(args[1]) == "" {
+			return fmt.Sprintf("Error: %s requires exactly one <scope>", args[0])
+		}
+	default:
+		return fmt.Sprintf("Unknown subcommand: %s", args[0])
+	}
+
+	return ""
+}
+
 func cmdRulesList(cfg *config.Config) int {
+	if err := requireLoadedConfig(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
 	rulesStore := engine.NewRules(cfg.ConfigDir)
 	for scope, ruleCfg := range cfg.User.Rules {
 		if !ruleCfg.Enabled {
@@ -199,6 +267,10 @@ func cmdRulesSetScopeEnabled(cfg *config.Config, args []string, enabled bool) in
 	}
 
 	key := fmt.Sprintf("rules.%s.enabled", scope)
+	if err := requireLoadedConfig(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
 	if err := cfg.Set(key, strconv.FormatBool(enabled)); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return 1
@@ -211,4 +283,18 @@ func cmdRulesSetScopeEnabled(cfg *config.Config, args []string, enabled bool) in
 
 	fmt.Printf("Disabled rule scope: %s\n", scope)
 	return 0
+}
+
+func requireConfigDirectory(cfg *config.Config) error {
+	if cfg == nil || cfg.ConfigDir == "" {
+		return errors.New("config directory unavailable; cannot persist changes")
+	}
+	return nil
+}
+
+func requireLoadedConfig(cfg *config.Config) error {
+	if err := requireConfigDirectory(cfg); err != nil {
+		return err
+	}
+	return cfg.LoadError()
 }

--- a/internal/cmd/config_stats_test.go
+++ b/internal/cmd/config_stats_test.go
@@ -305,14 +305,18 @@ func TestConfigCommandErrors(t *testing.T) {
 		wantIn string
 	}{
 		{name: "missing subcommand", args: []string{"typo", "config"}, wantIn: "subcommand required"},
+		{name: "list extra argument", args: []string{"typo", "config", "list", "extra"}, wantIn: "config list does not accept arguments"},
 		{name: "missing get key", args: []string{"typo", "config", "get"}, wantIn: "<key> required"},
+		{name: "get extra argument", args: []string{"typo", "config", "get", "keyboard", "extra"}, wantIn: "config get requires exactly <key>"},
 		{name: "unknown get key", args: []string{"typo", "config", "get", "unknown"}, wantIn: "unknown config key"},
 		{name: "missing set value", args: []string{"typo", "config", "set", "keyboard"}, wantIn: "<key> and <value> required"},
+		{name: "set extra argument", args: []string{"typo", "config", "set", "keyboard", "dvorak", "extra"}, wantIn: "config set requires exactly <key> and <value>"},
 		{name: "invalid set value", args: []string{"typo", "config", "set", "history.enabled", "maybe"}, wantIn: "invalid bool value"},
 		{name: "invalid experimental set value", args: []string{"typo", "config", "set", "experimental.long-option-correction.enabled", "maybe"}, wantIn: "invalid bool value"},
 		{name: "invalid auto learn threshold", args: []string{"typo", "config", "set", "auto-learn-threshold", "wat"}, wantIn: "invalid int value"},
 		{name: "gen positional args", args: []string{"typo", "config", "gen", "extra"}, wantIn: "does not accept positional arguments"},
 		{name: "gen invalid flag", args: []string{"typo", "config", "gen", "--wat"}, wantIn: "flag provided but not defined"},
+		{name: "reset extra argument", args: []string{"typo", "config", "reset", "extra"}, wantIn: "config reset does not accept arguments"},
 		{name: "unknown subcommand", args: []string{"typo", "config", "wat"}, wantIn: "Unknown subcommand"},
 	}
 
@@ -370,5 +374,70 @@ func TestConfigCommandWriteFailures(t *testing.T) {
 				t.Fatalf("expected write failure stderr, got stdout=%q stderr=%q", stdout, stderr)
 			}
 		})
+	}
+}
+
+func TestConfigCommandsRejectUnavailableDirectory(t *testing.T) {
+	cfg := &config.Config{User: config.DefaultUserConfig()}
+	tests := []struct {
+		name string
+		run  func() int
+	}{
+		{name: "set", run: func() int { return cmdConfigSet(cfg, []string{"set", "keyboard", "dvorak"}) }},
+		{name: "reset", run: func() int { return cmdConfigReset(cfg) }},
+		{name: "generate", run: func() int { return cmdConfigGen(cfg, []string{"gen"}) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if code := tt.run(); code != 1 {
+				t.Fatalf("command should reject an unavailable config directory: code=%d", code)
+			}
+		})
+	}
+	if err := requireConfigDirectory(nil); err == nil {
+		t.Fatal("nil config should not be writable")
+	}
+}
+
+func TestConfigSetPreservesInvalidFileAndResetRecovers(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	configDir := filepath.Join(tmpHome, ".typo")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	configFile := filepath.Join(configDir, "config.json")
+	invalid := []byte(`{"similarity_threshold":2}`)
+	if err := os.WriteFile(configFile, invalid, 0600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	cfg := config.Load()
+	if code := cmdConfigList(cfg); code != 1 {
+		t.Fatalf("config list should reject an invalid loaded file: code=%d", code)
+	}
+	if code := cmdConfigGet(cfg, []string{"get", "keyboard"}); code != 1 {
+		t.Fatalf("config get should reject an invalid loaded file: code=%d", code)
+	}
+	if code := cmdRulesList(cfg); code != 1 {
+		t.Fatalf("rules list should reject an invalid loaded file: code=%d", code)
+	}
+	if code := cmdConfigSet(cfg, []string{"set", "keyboard", "dvorak"}); code != 1 {
+		t.Fatalf("config set should reject an invalid loaded file: code=%d", code)
+	}
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	if !bytes.Equal(data, invalid) {
+		t.Fatalf("config set overwrote invalid input: %q", data)
+	}
+
+	if code := cmdConfigReset(cfg); code != 0 {
+		t.Fatalf("config reset should recover an invalid file: code=%d", code)
+	}
+	if cfg.LoadError() != nil {
+		t.Fatalf("successful reset should clear the load error: %v", cfg.LoadError())
 	}
 }

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -29,8 +29,8 @@ func cmdDoctor(args []string) int {
 	fmt.Println("Checking typo configuration...")
 	fmt.Println()
 
-	hasError := false
 	cfg := config.Load()
+	hasError := cfg.LoadError() != nil
 	shellName, shellRC := detectShellIntegrationTarget()
 
 	// Check if typo is in PATH
@@ -62,7 +62,9 @@ func cmdDoctor(args []string) int {
 
 	// Check config file and print effective settings
 	fmt.Print("[3/6] config file: ")
-	if configFile := cfg.ConfigFilePath(); configFile != "" {
+	if loadErr := cfg.LoadError(); loadErr != nil {
+		fmt.Printf("✗ %v\n", loadErr)
+	} else if configFile := cfg.ConfigFilePath(); configFile != "" {
 		if info, err := statPath(configFile); err == nil && !info.IsDir() {
 			fmt.Printf("✓ %s\n", configFile)
 		} else {
@@ -262,7 +264,13 @@ func (r *doctorJSONReport) addDoctorJSONConfigChecks(cfg *config.Config, configF
 		r.addDoctorCheck("config_directory", "config directory", "info", "will be created on first use", cfg.ConfigDir)
 	}
 
-	if configFile != "" {
+	if loadErr := cfg.LoadError(); loadErr != nil {
+		if info, err := statPath(configFile); err == nil && !info.IsDir() {
+			r.Config.FileExists = true
+		}
+		r.OK = false
+		r.addDoctorCheck("config_file", "config file", "fail", loadErr.Error(), configFile)
+	} else if configFile != "" {
 		if info, err := statPath(configFile); err == nil && !info.IsDir() {
 			r.Config.FileExists = true
 			r.addDoctorCheck("config_file", "config file", "pass", configFile, configFile)

--- a/internal/cmd/doctor_unit_test.go
+++ b/internal/cmd/doctor_unit_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/yuluo-yx/typo/internal/config"
 )
 
 func TestCheckDoctorShellIntegrationWithoutShellName(t *testing.T) {
@@ -174,4 +176,37 @@ func TestDoctorJSONShellSupportHelpers(t *testing.T) {
 	if shellSupportsAliasContext("") {
 		t.Fatal("unknown shell should not report alias context support")
 	}
+}
+
+func TestDoctorJSONConfigChecksRejectInvalidConfig(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	configDir := filepath.Join(tmpHome, ".typo")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	configFile := filepath.Join(configDir, "config.json")
+	if err := os.WriteFile(configFile, []byte(`{"similarity_threshold":2}`), 0600); err != nil {
+		t.Fatalf("write invalid config: %v", err)
+	}
+
+	cfg := config.Load()
+	if cfg.LoadError() == nil {
+		t.Fatal("invalid config should retain its load error")
+	}
+	report := doctorJSONReport{OK: true}
+	report.addDoctorJSONConfigChecks(cfg, configFile)
+	if report.OK {
+		t.Fatal("invalid config should fail the doctor report")
+	}
+
+	for _, check := range report.Checks {
+		if check.ID == "config_file" {
+			if check.Status != "fail" || !strings.Contains(check.Message, "similarity_threshold") {
+				t.Fatalf("unexpected config check: %+v", check)
+			}
+			return
+		}
+	}
+	t.Fatal("doctor report omitted the config_file check")
 }

--- a/internal/cmd/fix.go
+++ b/internal/cmd/fix.go
@@ -57,15 +57,18 @@ func cmdFix(args []string) int {
 		AliasContext: loadAliasContext(opts.aliasContextFile),
 	}
 
-	result := eng.FixWithContext(input)
+	var result itypes.FixResult
 	if opts.selectMode && cfg.User.Candidates.Enabled {
 		selected, ok := selectFixResult(eng, input, cfg.User.Candidates.Limit)
 		if !ok {
 			return 1
 		}
 		result = selected
-	} else if opts.selectMode {
-		fmt.Fprintln(os.Stderr, "typo: --select ignored because candidates.enabled=false; run `typo config set candidates.enabled true` to enable the candidate menu")
+	} else {
+		result = eng.FixWithContext(input)
+		if opts.selectMode {
+			fmt.Fprintln(os.Stderr, "typo: --select ignored because candidates.enabled=false; run `typo config set candidates.enabled true` to enable the candidate menu")
+		}
 	}
 
 	if result.Fixed {

--- a/internal/cmd/history.go
+++ b/internal/cmd/history.go
@@ -9,8 +9,8 @@ import (
 )
 
 func cmdHistory(args []string) int {
-	if len(args) < 1 {
-		fmt.Fprintln(os.Stderr, "Error: subcommand required (list, clear)")
+	if message := historyArgsError(args); message != "" {
+		fmt.Fprintln(os.Stderr, message)
 		return 1
 	}
 
@@ -25,6 +25,10 @@ func cmdHistory(args []string) int {
 		}
 		return 0
 	case "clear":
+		if err := requireConfigDirectory(cfg); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
 		if err := h.Clear(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			return 1
@@ -35,4 +39,25 @@ func cmdHistory(args []string) int {
 		fmt.Fprintf(os.Stderr, "Unknown subcommand: %s\n", args[0])
 		return 1
 	}
+}
+
+func historyArgsError(args []string) string {
+	if len(args) == 0 {
+		return "Error: subcommand required (list, clear)"
+	}
+
+	switch args[0] {
+	case "list":
+		if len(args) != 1 {
+			return "Error: history list does not accept arguments"
+		}
+	case "clear":
+		if len(args) != 1 {
+			return "Error: history clear does not accept arguments"
+		}
+	default:
+		return fmt.Sprintf("Unknown subcommand: %s", args[0])
+	}
+
+	return ""
 }

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -11,6 +11,10 @@ func cmdInit(args []string) int {
 		fmt.Fprintln(os.Stderr, "Error: shell required (zsh, bash, fish, powershell)")
 		return 1
 	}
+	if len(args) != 1 {
+		fmt.Fprintln(os.Stderr, "Error: init requires exactly one shell")
+		return 1
+	}
 
 	switch normalizeShellName(args[0]) {
 	case "zsh":

--- a/internal/cmd/learn.go
+++ b/internal/cmd/learn.go
@@ -8,12 +8,16 @@ import (
 )
 
 func cmdLearn(args []string) int {
-	if len(args) < 2 {
-		fmt.Fprintln(os.Stderr, "Error: <from> and <to> required")
+	if len(args) != 2 {
+		fmt.Fprintln(os.Stderr, "Error: exactly two arguments required: <from> and <to>")
 		return 1
 	}
 
 	cfg := config.Load()
+	if err := requireConfigDirectory(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
 	eng := createEngine(cfg)
 
 	if err := eng.Learn(args[0], args[1]); err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -89,12 +89,11 @@ func Run() int {
 	case "init":
 		return cmdInit(os.Args[2:])
 	case "version":
-		cmdVersion()
-		return 0
+		return cmdVersion(os.Args[2:])
 	case "doctor":
 		return cmdDoctor(os.Args[2:])
 	case "uninstall":
-		return cmdUninstall()
+		return cmdUninstall(os.Args[2:])
 	case "update", "upgrade":
 		return cmdUpdate(os.Args[2:])
 	case "help", "-h", "--help":

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -51,6 +51,12 @@ func TestRun(t *testing.T) {
 			wantOutput: "typo",
 		},
 		{
+			name:       "version extra argument",
+			args:       []string{"typo", "version", "extra"},
+			wantCode:   1,
+			wantOutput: "does not accept arguments",
+		},
+		{
 			name:       "no args",
 			args:       []string{"typo"},
 			wantCode:   1,
@@ -97,6 +103,18 @@ func TestRun(t *testing.T) {
 			args:       []string{"typo", "init", "pwsh"},
 			wantCode:   0,
 			wantOutput: "Set-PSReadLineKeyHandler",
+		},
+		{
+			name:       "init extra argument",
+			args:       []string{"typo", "init", "zsh", "extra"},
+			wantCode:   1,
+			wantOutput: "requires exactly one shell",
+		},
+		{
+			name:       "uninstall extra argument",
+			args:       []string{"typo", "uninstall", "extra"},
+			wantCode:   1,
+			wantOutput: "does not accept arguments",
 		},
 		{
 			name:       "learn without args",
@@ -359,7 +377,9 @@ func TestCmdVersion(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	cmdVersion()
+	if code := cmdVersion(nil); code != 0 {
+		t.Fatalf("cmdVersion() = %d, want 0", code)
+	}
 
 	if err := w.Close(); err != nil {
 		t.Fatalf("Close pipe failed: %v", err)

--- a/internal/cmd/rules_history_test.go
+++ b/internal/cmd/rules_history_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestRulesList(t *testing.T) {
+	useTempHome(t)
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 
@@ -44,6 +45,7 @@ func TestRulesList(t *testing.T) {
 }
 
 func TestRulesAddRemove(t *testing.T) {
+	useTempHome(t)
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 
@@ -84,6 +86,7 @@ func TestRulesAddRemove(t *testing.T) {
 }
 
 func TestRulesAddMissingArgs(t *testing.T) {
+	useTempHome(t)
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 
@@ -105,7 +108,60 @@ func TestRulesAddMissingArgs(t *testing.T) {
 	}
 }
 
+func TestLearnAndRulesAddRejectExtraArguments(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "learn", args: []string{"typo", "learn", "from", "to", "extra"}},
+		{name: "rules add", args: []string{"typo", "rules", "add", "from", "to", "extra"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpHome := useTempHome(t)
+			code, stdout, stderr := runCLI(t, tt.args)
+			if code != 1 {
+				t.Fatalf("extra arguments should fail: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+			}
+			if !strings.Contains(stderr, "exactly two arguments required") {
+				t.Fatalf("missing argument error: %q", stderr)
+			}
+			if _, ok := engine.NewRules(filepath.Join(tmpHome, ".typo")).MatchUser("from"); ok {
+				t.Fatal("rejected command persisted a user rule")
+			}
+		})
+	}
+}
+
+func TestLearnAndRulesAddRejectInvalidRules(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "learn empty source", args: []string{"typo", "learn", "", "git"}},
+		{name: "learn empty target", args: []string{"typo", "learn", "bad", ""}},
+		{name: "learn unchanged", args: []string{"typo", "learn", "same", "same"}},
+		{name: "rules add empty target", args: []string{"typo", "rules", "add", "bad", " "}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpHome := useTempHome(t)
+			code, stdout, stderr := runCLI(t, tt.args)
+			if code != 1 || stdout != "" {
+				t.Fatalf("invalid rule should fail without stdout: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+			}
+			rulesFile := filepath.Join(tmpHome, ".typo", "rules.json")
+			if _, err := os.Stat(rulesFile); !os.IsNotExist(err) {
+				t.Fatalf("invalid rule should not be persisted: %v", err)
+			}
+		})
+	}
+}
+
 func TestRulesRemoveMissingArgs(t *testing.T) {
+	useTempHome(t)
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 
@@ -127,7 +183,16 @@ func TestRulesRemoveMissingArgs(t *testing.T) {
 	}
 }
 
+func TestRulesRemoveRejectsExtraArguments(t *testing.T) {
+	useTempHome(t)
+	code, stdout, stderr := runCLI(t, []string{"typo", "rules", "remove", "from", "extra"})
+	if code != 1 || stdout != "" || !strings.Contains(stderr, "remove requires exactly") {
+		t.Fatalf("rules remove extra argument: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+}
+
 func TestRulesUnknownSubcommand(t *testing.T) {
+	useTempHome(t)
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 
@@ -299,6 +364,7 @@ func TestRulesEnableDisableSupportsUnknownPresentScope(t *testing.T) {
 }
 
 func TestHistoryList(t *testing.T) {
+	useTempHome(t)
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 
@@ -327,6 +393,7 @@ func TestHistoryList(t *testing.T) {
 }
 
 func TestHistoryClear(t *testing.T) {
+	useTempHome(t)
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 
@@ -348,7 +415,77 @@ func TestHistoryClear(t *testing.T) {
 	}
 }
 
+func TestRulesAndHistoryRejectExtraArguments(t *testing.T) {
+	useTempHome(t)
+	for _, tt := range []struct {
+		name   string
+		args   []string
+		wantIn string
+	}{
+		{name: "rules list", args: []string{"typo", "rules", "list", "extra"}, wantIn: "rules list does not accept arguments"},
+		{name: "history list", args: []string{"typo", "history", "list", "extra"}, wantIn: "history list does not accept arguments"},
+		{name: "history clear", args: []string{"typo", "history", "clear", "extra"}, wantIn: "history clear does not accept arguments"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			code, stdout, stderr := runCLI(t, tt.args)
+			if code != 1 || stdout != "" || !strings.Contains(stderr, tt.wantIn) {
+				t.Fatalf("extra arguments should fail: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+			}
+		})
+	}
+}
+
+func TestHistoryClearExtraArgumentDoesNotMutateHistory(t *testing.T) {
+	useTempHome(t)
+	cfg := config.Load()
+	history := engine.NewHistory(cfg.ConfigDir)
+	if err := history.Record("gti status", "git status"); err != nil {
+		t.Fatalf("Record failed: %v", err)
+	}
+
+	code, _, _ := runCLI(t, []string{"typo", "history", "clear", "extra"})
+	if code != 1 {
+		t.Fatalf("history clear with extra argument should fail: code=%d", code)
+	}
+	if _, ok := engine.NewHistory(cfg.ConfigDir).Lookup("gti status"); !ok {
+		t.Fatal("rejected history clear removed existing history")
+	}
+}
+
+func TestRejectedHistoryCommandDoesNotLoadInvalidHistory(t *testing.T) {
+	tmpHome := useTempHome(t)
+	configDir := filepath.Join(tmpHome, ".typo")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	historyFile := filepath.Join(configDir, "usage_history.json")
+	const invalidHistory = "not-json"
+	if err := os.WriteFile(historyFile, []byte(invalidHistory), 0600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	code, stdout, stderr := runCLI(t, []string{"typo", "history", "clear", "extra"})
+	if code != 1 || stdout != "" || !strings.Contains(stderr, "does not accept arguments") {
+		t.Fatalf("invalid history command: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	data, err := os.ReadFile(historyFile)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	if string(data) != invalidHistory {
+		t.Fatalf("rejected command changed invalid history: %q", data)
+	}
+	backups, err := filepath.Glob(historyFile + ".corrupt-*")
+	if err != nil {
+		t.Fatalf("Glob failed: %v", err)
+	}
+	if len(backups) != 0 {
+		t.Fatalf("rejected command quarantined history: %v", backups)
+	}
+}
+
 func TestRulesRemoveNonexistent(t *testing.T) {
+	useTempHome(t)
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 
@@ -371,6 +508,7 @@ func TestRulesRemoveNonexistent(t *testing.T) {
 }
 
 func TestHistoryUnknownSubcommand(t *testing.T) {
+	useTempHome(t)
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 

--- a/internal/cmd/shell_integration_uninstall_test.go
+++ b/internal/cmd/shell_integration_uninstall_test.go
@@ -156,6 +156,33 @@ _typo_bashexit
 `)
 }
 
+func TestBashIntegrationPreservesUserFileDescriptorThree(t *testing.T) {
+	runBashIntegrationScript(t, `
+fd3_log="$TMPDIR/fd3.log"
+exec 3>"$fd3_log"
+
+source "$1"
+trap - DEBUG
+
+[[ "$TYPO_ORIG_STDERR_FD" != 3 ]] || exit 55
+printf "after-source\n" >&3
+
+_typo_preexec
+printf "captured-stderr\n" >&2
+_typo_precmd
+printf "after-rotate\n" >&3
+grep -q "captured-stderr" "$TYPO_STDERR_CACHE" || exit 56
+
+_typo_bashexit
+printf "after-exit\n" >&3
+exec 3>&-
+
+expected=$(printf "after-source\nafter-rotate\nafter-exit")
+actual=$(cat "$fd3_log")
+[[ "$actual" == "$expected" ]] || { printf "%s\n" "$actual"; exit 57; }
+`)
+}
+
 func TestBashIntegrationFallsBackWhenMktempFails(t *testing.T) {
 	runBashIntegrationScript(t, `
 mktemp() { return 1; }

--- a/internal/cmd/uninstall.go
+++ b/internal/cmd/uninstall.go
@@ -2,12 +2,18 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/yuluo-yx/typo/internal/config"
 )
 
-func cmdUninstall() int {
+func cmdUninstall(args []string) int {
+	if len(args) != 0 {
+		fmt.Fprintln(os.Stderr, "Error: uninstall does not accept arguments")
+		return 1
+	}
+
 	fmt.Println("Cleaning up typo...")
 	fmt.Println()
 

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -81,6 +81,9 @@ func parseUpdateFlags(args []string) (updateFlags, error) {
 	if err := fs.Parse(args); err != nil {
 		return flags, err
 	}
+	if fs.NArg() != 0 {
+		return flags, fmt.Errorf("update does not accept positional arguments")
+	}
 	return flags, nil
 }
 

--- a/internal/cmd/update_test.go
+++ b/internal/cmd/update_test.go
@@ -219,6 +219,37 @@ func TestCmdUpdateFlagParsingHandlesHelpAndBadFlags(t *testing.T) {
 	}
 }
 
+func TestCmdUpdateRejectsPositionalArgumentsBeforeRunningUpdate(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "after flag", args: []string{"--dry-run", "unexpected"}},
+		{name: "before flag", args: []string{"unexpected", "--dry-run"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			typoPath := filepath.Join(t.TempDir(), ".local", "bin", "typo")
+			calls := withUpdateTestHooks(t, typoPath)
+
+			code, stdout, stderr := captureUpdateOutput(t, func() int {
+				return cmdUpdate(tt.args)
+			})
+
+			if code != 1 {
+				t.Fatalf("positional arguments should fail: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+			}
+			if !strings.Contains(stderr, "update does not accept positional arguments") {
+				t.Fatalf("missing positional argument error: %q", stderr)
+			}
+			if len(*calls) != 0 {
+				t.Fatalf("rejected update ran command hooks: %#v", *calls)
+			}
+		})
+	}
+}
+
 func TestResolveRunningTypoInstallReportsExecutableError(t *testing.T) {
 	origExecutable := executable
 	defer func() { executable = origExecutable }()

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -2,12 +2,19 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"time"
 )
 
-func cmdVersion() {
+func cmdVersion(args []string) int {
+	if len(args) != 0 {
+		fmt.Fprintln(os.Stderr, "Error: version does not accept arguments")
+		return 1
+	}
+
 	resolvedVersion, resolvedCommit, resolvedDate := resolveVersionInfo()
 	fmt.Printf("typo %s (commit: %s, built: %s)\n", resolvedVersion, resolvedCommit, resolvedDate)
+	return 0
 }
 
 // Prefer release metadata injected by the build pipeline; fall back to VCS metadata embedded in the Go binary when needed.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	ConfigDir string
 	Debug     bool
 	User      itypes.UserConfig
+	loadErr   error
 }
 
 // Setting represents one config item displayed by the CLI.
@@ -156,6 +157,14 @@ func (c *Config) ConfigFilePath() string {
 		return ""
 	}
 	return filepath.Join(c.ConfigDir, configFileName)
+}
+
+// LoadError 返回最近一次加载配置文件时遇到的错误。
+func (c *Config) LoadError() error {
+	if c == nil {
+		return nil
+	}
+	return c.loadErr
 }
 
 // Save validates and writes the current user config to disk.
@@ -440,6 +449,7 @@ func ValidateUserConfig(u itypes.UserConfig) error {
 }
 
 func (c *Config) loadUserConfig() {
+	c.loadErr = nil
 	configFile := c.ConfigFilePath()
 	if configFile == "" {
 		return
@@ -447,11 +457,15 @@ func (c *Config) loadUserConfig() {
 
 	data, err := os.ReadFile(configFile)
 	if err != nil {
+		if !os.IsNotExist(err) {
+			c.loadErr = fmt.Errorf("read config file %s: %w", configFile, err)
+		}
 		return
 	}
 
 	var fileCfg fileUserConfig
 	if err := json.Unmarshal(data, &fileCfg); err != nil {
+		c.loadErr = fmt.Errorf("parse config file %s: %w", configFile, err)
 		storage.QuarantineInvalidJSON(configFile, err)
 		return
 	}
@@ -459,7 +473,8 @@ func (c *Config) loadUserConfig() {
 	userCfg := DefaultUserConfig()
 	applyFileConfig(&userCfg, fileCfg)
 	if err := ValidateUserConfig(userCfg); err != nil {
-		fmt.Fprintf(os.Stderr, "typo: invalid config file %s: %v\n", configFile, err)
+		c.loadErr = fmt.Errorf("invalid config file %s: %w", configFile, err)
+		fmt.Fprintf(os.Stderr, "typo: %v\n", c.loadErr)
 		return
 	}
 	if unknownScopes := unknownRuleScopes(userCfg.Rules); len(unknownScopes) > 0 {
@@ -543,7 +558,11 @@ func (c *Config) saveUserConfig(user itypes.UserConfig) error {
 	if configFile == "" {
 		return nil
 	}
-	return storage.WriteFileAtomic(configFile, data, 0600)
+	if err := storage.WriteFileAtomic(configFile, data, 0600); err != nil {
+		return err
+	}
+	c.loadErr = nil
+	return nil
 }
 
 func cloneUserConfig(src itypes.UserConfig) itypes.UserConfig {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -159,7 +159,7 @@ func (c *Config) ConfigFilePath() string {
 	return filepath.Join(c.ConfigDir, configFileName)
 }
 
-// LoadError 返回最近一次加载配置文件时遇到的错误。
+// LoadError returns the error encountered while most recently loading the config file.
 func (c *Config) LoadError() error {
 	if c == nil {
 		return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -674,6 +674,20 @@ func TestLoad_InvalidJSONAndInvalidConfigFallBackToDefaults(t *testing.T) {
 	})
 }
 
+func TestLoadErrorReportsInvalidJSON(t *testing.T) {
+	configDir := t.TempDir()
+	configFile := filepath.Join(configDir, configFileName)
+	if err := os.WriteFile(configFile, []byte("{"), 0600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	cfg := &Config{ConfigDir: configDir, User: DefaultUserConfig()}
+	cfg.loadUserConfig()
+	if cfg.LoadError() == nil {
+		t.Fatal("LoadError() should report invalid JSON")
+	}
+}
+
 func TestLoad_AllowsUnknownRuleScopesWithWarning(t *testing.T) {
 	tmpHome := t.TempDir()
 	oldHome := os.Getenv("HOME")

--- a/internal/engine/auto_learn.go
+++ b/internal/engine/auto_learn.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	itypes "github.com/yuluo-yx/typo/internal/types"
@@ -124,10 +125,29 @@ func (e *Engine) promoteAutoLearnHistory(ctx context.Context, from, to string) a
 	}
 
 	if err := autoLearnContextErr(ctx); err != nil {
-		return autoLearnResultWithErr(result, err)
+		return e.rollbackPromotedAutoLearnRule(result, from, err)
 	}
 
-	return e.markAutoLearnRuleApplied(result, from, to)
+	result = e.markAutoLearnRuleApplied(result, from, to)
+	if result.Err != nil {
+		return e.rollbackPromotedAutoLearnRule(result, from, result.Err)
+	}
+	if !result.Persisted {
+		return e.rollbackPromotedAutoLearnRule(
+			result,
+			from,
+			errors.New("history pair changed before auto-learn could be finalized"),
+		)
+	}
+	return result
+}
+
+func (e *Engine) rollbackPromotedAutoLearnRule(result autoLearnResult, from string, cause error) autoLearnResult {
+	if rollbackErr := e.rules.RemoveUserRule(from); rollbackErr != nil {
+		cause = errors.Join(cause, fmt.Errorf("roll back auto-learned rule: %w", rollbackErr))
+	}
+	result.Persisted = false
+	return autoLearnResultWithErr(result, cause)
 }
 
 func (e *Engine) markAutoLearnRuleApplied(result autoLearnResult, from, to string) autoLearnResult {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1577,7 +1577,7 @@ func (e *Engine) storeUserRule(from, to string) error {
 	return nil
 }
 
-// RemoveRule 删除用户规则，并以同一操作清理相关纠错历史。
+// RemoveRule removes a user rule and clears its related correction history in the same operation.
 func (e *Engine) RemoveRule(from string) error {
 	from = strings.TrimSpace(from)
 	previous, existed := e.rules.MatchUser(from)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -159,10 +160,18 @@ func (e *Engine) tryParser(input itypes.ParserContext) itypes.FixResult {
 	lines, err := parseShellCommandLines(input.Command)
 	if err == nil {
 		hasMultipleCommands := len(lines) > 1
+		usableLine := false
+		var matchedLine *shellCommandLine
+		var matchedResult itypes.ParserResult
 
 		for _, line := range lines {
+			command := line.commandSuffixRaw()
+			if command == "" {
+				continue
+			}
+			usableLine = true
 			result := e.parser.Parse(itypes.ParserContext{
-				Command:             line.commandSuffixRaw(),
+				Command:             command,
 				Stderr:              input.Stderr,
 				ExitCode:            input.ExitCode,
 				HasMultipleCommands: hasMultipleCommands,
@@ -170,17 +179,26 @@ func (e *Engine) tryParser(input itypes.ParserContext) itypes.FixResult {
 				HasPrivilegeWrapper: line.hasWrapper("sudo"),
 			})
 			if result.Fixed {
-				return itypes.FixResult{
-					Fixed:   true,
-					Command: line.replaceCommandSuffix(result.Command),
-					Source:  fixSourceParser,
-					Message: result.Message,
-					Kind:    result.Kind,
+				if matchedLine != nil {
+					return itypes.FixResult{Fixed: false}
 				}
+				matchedLine = line
+				matchedResult = result
 			}
 		}
 
-		return itypes.FixResult{Fixed: false}
+		if matchedLine != nil {
+			return itypes.FixResult{
+				Fixed:   true,
+				Command: matchedLine.replaceCommandSuffix(matchedResult.Command),
+				Source:  fixSourceParser,
+				Message: matchedResult.Message,
+				Kind:    matchedResult.Kind,
+			}
+		}
+		if usableLine {
+			return itypes.FixResult{Fixed: false}
+		}
 	}
 
 	result := e.parser.Parse(itypes.ParserContext{
@@ -323,7 +341,7 @@ func tryMatch(cmd, source string, match matchFunc) itypes.FixResult {
 		if replacement, ok := match(parts[0]); ok {
 			return itypes.FixResult{
 				Fixed:   true,
-				Command: replacement + " " + strings.Join(parts[1:], " "),
+				Command: replaceFirstField(cmd, parts[0], replacement),
 				Source:  source,
 			}
 		}
@@ -383,13 +401,8 @@ func (e *Engine) tryDistance(cmd string) itypes.FixResult {
 	if bestMatch != "" && bestMatch != cmdWord && isGoodCommandDistanceMatch(cmdWord, bestMatch, bestDistance, e.distanceMatchConfig()) {
 		result := itypes.FixResult{
 			Fixed:   true,
-			Command: bestMatch,
+			Command: replaceFirstField(cmd, cmdWord, bestMatch),
 			Source:  fixSourceDistance,
-		}
-
-		// Add original args
-		if len(parts) > 1 {
-			result.Command = bestMatch + " " + strings.Join(parts[1:], " ")
 		}
 
 		// Also try to fix subcommand
@@ -465,13 +478,9 @@ func (e *Engine) distanceFixCandidates(cmd string, limit int) []itypes.FixResult
 		if candidate.name == parts[0] {
 			continue
 		}
-		command := candidate.name
-		if len(parts) > 1 {
-			command += " " + strings.Join(parts[1:], " ")
-		}
 		result := itypes.FixResult{
 			Fixed:   true,
-			Command: command,
+			Command: replaceFirstField(cmd, parts[0], candidate.name),
 			Source:  fixSourceDistance,
 		}
 		if e.toolTrees != nil {
@@ -486,6 +495,14 @@ func (e *Engine) distanceFixCandidates(cmd string, limit int) []itypes.FixResult
 	}
 
 	return results
+}
+
+func replaceFirstField(raw, field, replacement string) string {
+	start := strings.Index(raw, field)
+	if start == -1 {
+		return raw
+	}
+	return raw[:start] + replacement + raw[start+len(field):]
 }
 
 func (e *Engine) distanceFixCandidatesWithShell(cmd string, limit int) ([]itypes.FixResult, bool) {
@@ -1527,20 +1544,56 @@ var builtinToolOptionsWithValues = map[string]map[string]bool{
 
 // Learn stores a user-taught correction as a rule instead of history.
 func (e *Engine) Learn(from, to string) error {
-	if err := e.rules.AddUserRule(itypes.Rule{From: from, To: to}); err != nil {
-		return err
-	}
-
-	return e.clearConflictingHistory(from)
+	return e.storeUserRule(from, to)
 }
 
 // AddRule adds a user rule.
 func (e *Engine) AddRule(from, to string) error {
-	if err := e.rules.AddUserRule(itypes.Rule{From: from, To: to}); err != nil {
+	return e.storeUserRule(from, to)
+}
+
+func (e *Engine) storeUserRule(from, to string) error {
+	rule, err := normalizeUserRule(itypes.Rule{From: from, To: to})
+	if err != nil {
 		return err
 	}
 
-	return e.clearConflictingHistory(from)
+	previous, existed := e.rules.MatchUser(rule.From)
+	if err := e.rules.AddUserRule(rule); err != nil {
+		return err
+	}
+	if err := e.clearConflictingHistory(rule.From); err != nil {
+		var rollbackErr error
+		if existed {
+			rollbackErr = e.rules.AddUserRule(previous)
+		} else {
+			rollbackErr = e.rules.RemoveUserRule(rule.From)
+		}
+		if rollbackErr != nil {
+			return errors.Join(err, fmt.Errorf("roll back user rule: %w", rollbackErr))
+		}
+		return err
+	}
+	return nil
+}
+
+// RemoveRule 删除用户规则，并以同一操作清理相关纠错历史。
+func (e *Engine) RemoveRule(from string) error {
+	from = strings.TrimSpace(from)
+	previous, existed := e.rules.MatchUser(from)
+	if !existed {
+		return ErrRuleNotFound
+	}
+	if err := e.rules.RemoveUserRule(from); err != nil {
+		return err
+	}
+	if err := e.clearConflictingHistory(from); err != nil {
+		if rollbackErr := e.rules.AddUserRule(previous); rollbackErr != nil {
+			return errors.Join(err, fmt.Errorf("roll back removed user rule: %w", rollbackErr))
+		}
+		return err
+	}
+	return nil
 }
 
 // ListRules returns all rules.

--- a/internal/engine/engine_helpers_test.go
+++ b/internal/engine/engine_helpers_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/yuluo-yx/typo/internal/commands"
@@ -27,6 +28,10 @@ func TestTryMatch(t *testing.T) {
 
 	if got := tryMatch("gut branch", "rule", match); !got.Fixed || got.Command != "git branch" {
 		t.Fatalf("Expected command word match, got %+v", got)
+	}
+
+	if got := tryMatch("gut commit -m 'a   b", "rule", match); !got.Fixed || got.Command != "git commit -m 'a   b" {
+		t.Fatalf("Expected fallback match to preserve the original suffix, got %+v", got)
 	}
 
 	if got := tryMatch("valid command", "rule", match); got.Fixed {
@@ -328,7 +333,7 @@ func TestEngine_TryDistance_FallbackBranches(t *testing.T) {
 		WithKeyboard(NewQWERTYKeyboard()),
 	)
 
-	if got := eng.tryDistance("myap '"); !got.Fixed || got.Command != "myapp '" || got.Source != "distance" {
+	if got := eng.tryDistance("myap 'a   b"); !got.Fixed || got.Command != "myapp 'a   b" || got.Source != "distance" {
 		t.Fatalf("Expected fallback distance fix, got %+v", got)
 	}
 
@@ -377,7 +382,7 @@ func TestEngine_TrySubcommandFix_FallbackBranches(t *testing.T) {
 	}
 }
 
-func TestEngine_TryParser_FallbackAndShell(t *testing.T) {
+func TestEngine_TryParser_ShellAndParseFailure(t *testing.T) {
 	eng := NewEngine(WithParser(parser.NewRegistry()))
 
 	stderr := "git: 'remove' is not a git command.\n\nThe most similar command is\n\tremote\n"
@@ -385,8 +390,8 @@ func TestEngine_TryParser_FallbackAndShell(t *testing.T) {
 		t.Fatalf("Expected shell parser fix, got %+v", got)
 	}
 
-	if got := eng.tryParser(itypes.ParserContext{Command: "git remove '", Stderr: stderr}); !got.Fixed || got.Command != "git remote '" {
-		t.Fatalf("Expected fallback parser fix, got %+v", got)
+	if got := eng.tryParser(itypes.ParserContext{Command: "git remove '", Stderr: stderr}); got.Fixed {
+		t.Fatalf("Expected malformed shell command to stay unchanged, got %+v", got)
 	}
 
 	if got := eng.tryParser(itypes.ParserContext{Command: "git status", Stderr: "unrecognized error"}); got.Fixed {
@@ -1228,6 +1233,69 @@ func TestEngine_LearnAndAddRule_ErrorPaths(t *testing.T) {
 	if err := eng.AddRule("broken2", "command2"); err == nil {
 		t.Fatal("Expected AddRule to fail when rules cannot be saved")
 	}
+}
+
+func TestEngine_UserRuleOperationsRollbackWhenHistoryCleanupFails(t *testing.T) {
+	setup := func(t *testing.T) (*Engine, *Rules, *History) {
+		t.Helper()
+		dir := t.TempDir()
+		rules := NewRules(dir)
+		history := NewHistory(dir)
+		if err := history.Record("typo status", "old status"); err != nil {
+			t.Fatalf("Record failed: %v", err)
+		}
+
+		historyFile := filepath.Join(dir, usageHistoryFileName)
+		if err := os.Remove(historyFile); err != nil {
+			t.Fatalf("Remove history file failed: %v", err)
+		}
+		if err := os.Mkdir(historyFile, 0700); err != nil {
+			t.Fatalf("Create blocking history directory failed: %v", err)
+		}
+
+		return NewEngine(WithRules(rules), WithHistory(history)), rules, history
+	}
+
+	t.Run("new rule", func(t *testing.T) {
+		eng, rules, history := setup(t)
+		if err := eng.Learn(" typo ", " command "); err == nil {
+			t.Fatal("Learn should fail when conflicting history cannot be saved")
+		}
+		if _, ok := rules.MatchUser("typo"); ok {
+			t.Fatal("failed Learn left the new rule active")
+		}
+		if _, ok := history.Lookup("typo status"); !ok {
+			t.Fatal("failed Learn did not restore conflicting history")
+		}
+	})
+
+	t.Run("replaced rule", func(t *testing.T) {
+		eng, rules, _ := setup(t)
+		if err := rules.AddUserRule(itypes.Rule{From: "typo", To: "old-command"}); err != nil {
+			t.Fatalf("seed rule failed: %v", err)
+		}
+		if err := eng.AddRule(" typo ", "new-command"); err == nil {
+			t.Fatal("AddRule should fail when conflicting history cannot be saved")
+		}
+		rule, ok := rules.MatchUser("typo")
+		if !ok || rule.To != "old-command" {
+			t.Fatalf("failed AddRule did not restore the previous rule: %+v, ok=%v", rule, ok)
+		}
+	})
+
+	t.Run("removed rule", func(t *testing.T) {
+		eng, rules, _ := setup(t)
+		if err := rules.AddUserRule(itypes.Rule{From: "typo", To: "command"}); err != nil {
+			t.Fatalf("seed rule failed: %v", err)
+		}
+		if err := eng.RemoveRule(" typo "); err == nil {
+			t.Fatal("RemoveRule should fail when conflicting history cannot be saved")
+		}
+		rule, ok := rules.MatchUser("typo")
+		if !ok || rule.To != "command" {
+			t.Fatalf("failed RemoveRule did not restore the rule: %+v, ok=%v", rule, ok)
+		}
+	})
 }
 
 func TestSimilarityAndCommandsEquivalent(t *testing.T) {

--- a/internal/engine/engine_helpers_test.go
+++ b/internal/engine/engine_helpers_test.go
@@ -1069,7 +1069,7 @@ func TestEngine_TrySubcommandFix_ThreeLevelCloudSubcommands(t *testing.T) {
 		},
 		{
 			name:    "az four-level network create with transpositions",
-			cmd:     "az netwrok vnet subent craete", //nolint:misspell // 故意保留拼错的命令输入。
+			cmd:     "az netwrok vnet subent craete", //nolint:misspell // Intentionally keep the misspelled command input.
 			wantCmd: "az network vnet subnet create",
 		},
 	}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -179,6 +179,62 @@ func TestEngine_FixWithParser(t *testing.T) {
 	}
 }
 
+func TestEngine_FixWithParser_RespectsExitCode(t *testing.T) {
+	eng := NewEngine(WithParser(parser.NewRegistry()))
+	stderr := "Error: unknown command \"upgraed\" for \"mytool\"\n\nDid you mean this?\n\tupgrade\n"
+
+	tests := []struct {
+		name     string
+		exitCode int
+		wantFix  bool
+	}{
+		{name: "successful command", exitCode: 0, wantFix: false},
+		{name: "failed command", exitCode: 1, wantFix: true},
+		{name: "unknown exit code", exitCode: -1, wantFix: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := eng.FixWithContext(itypes.ParserContext{
+				Command:  "mytool upgraed",
+				Stderr:   stderr,
+				ExitCode: tt.exitCode,
+			})
+			if result.Fixed != tt.wantFix {
+				t.Fatalf("FixWithContext().Fixed = %v, want %v; result = %+v", result.Fixed, tt.wantFix, result)
+			}
+			if tt.wantFix && result.Command != "mytool upgrade" {
+				t.Fatalf("FixWithContext().Command = %q, want %q", result.Command, "mytool upgrade")
+			}
+		})
+	}
+}
+
+func TestEngine_Fix_FishDecorators(t *testing.T) {
+	eng := NewEngine(WithCommands([]string{"git", "docker"}))
+
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{name: "fish and", command: "gti status; and dcoker ps", want: "git status; and docker ps"},
+		{name: "fish or", command: "gti status; or dcoker ps", want: "git status; or docker ps"},
+		{name: "fish not", command: "not gti status", want: "not git status"},
+		{name: "bash and", command: "gti status && dcoker ps", want: "git status && docker ps"},
+		{name: "bash or", command: "gti status || dcoker ps", want: "git status || docker ps"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := eng.Fix(tt.command, "")
+			if !result.Fixed || result.Command != tt.want {
+				t.Fatalf("Fix(%q) = %+v, want command %q", tt.command, result, tt.want)
+			}
+		})
+	}
+}
+
 func TestEngine_FixWithParser_ClearsStderrAfterFirstParserFix(t *testing.T) {
 	tmpDir := t.TempDir()
 	subcommands := commands.NewToolTreeRegistry(tmpDir)
@@ -190,8 +246,9 @@ func TestEngine_FixWithParser_ClearsStderrAfterFirstParserFix(t *testing.T) {
 	)
 
 	result := eng.FixWithContext(itypes.ParserContext{
-		Command: "git remove -v && dcoker ps",
-		Stderr:  "git: 'remove' is not a git command. See 'git --help'.\n\nThe most similar command is\n\tremote\n",
+		Command:  "git remove -v && dcoker ps",
+		Stderr:   "git: 'remove' is not a git command. See 'git --help'.\n\nThe most similar command is\n\tremote\n",
+		ExitCode: 1,
 	})
 	if !result.Fixed {
 		t.Fatal("Expected parser fix to be followed by normal typo fixes")
@@ -204,37 +261,68 @@ func TestEngine_FixWithParser_ClearsStderrAfterFirstParserFix(t *testing.T) {
 	}
 }
 
-func TestEngine_FixWithParser_NoUpstreamTargetsPullOnly(t *testing.T) {
+func TestEngine_FixWithParser_PullUpstreamHintStaysUnchanged(t *testing.T) {
 	eng := NewEngine(
 		WithParser(parser.NewRegistry()),
 	)
 
 	result := eng.FixWithContext(itypes.ParserContext{
-		Command: "git remove -v && git pull",
-		Stderr:  "There is no tracking information for the current branch.\nPlease specify which branch you want to merge with.\nSee git-pull(1) for details.\n\n    git pull <remote> <branch>\n\nIf you wish to set tracking information for this branch, you can do so with:\n\n    git branch --set-upstream-to=origin/main main\n",
+		Command:  "git remove -v && git pull",
+		Stderr:   "There is no tracking information for the current branch.\nPlease specify which branch you want to merge with.\nSee git-pull(1) for details.\n\n    git pull <remote> <branch>\n\nIf you wish to set tracking information for this branch, you can do so with:\n\n    git branch --set-upstream-to=origin/main main\n",
+		ExitCode: 1,
 	})
-	if !result.Fixed {
-		t.Fatal("Expected pull command to be fixed")
-	}
-	if result.Command != "git remove -v && git pull --set-upstream origin main" {
-		t.Fatalf("Expected upstream fix to apply only to git pull, got %q", result.Command)
+	if result.Fixed {
+		t.Fatalf("Expected pull upstream target to remain user-controlled, got %+v", result)
 	}
 }
 
-func TestEngine_FixWithParser_NoUpstreamDefaultsPlaceholderRemoteToOrigin(t *testing.T) {
+func TestEngine_FixWithParser_NoUpstreamDoesNotGuessPlaceholders(t *testing.T) {
 	eng := NewEngine(
 		WithParser(parser.NewRegistry()),
 	)
 
 	result := eng.FixWithContext(itypes.ParserContext{
-		Command: "git remove -v && git pull",
-		Stderr:  "There is no tracking information for the current branch.\nPlease specify which branch you want to merge with.\nSee git-pull(1) for details.\n\n    git pull <remote> <branch>\n\nIf you wish to set tracking information for this branch you can do so with:\n\n    git branch --set-upstream-to=<remote>/<branch> 0426-yuluo/fix\n",
+		Command:  "git remove -v && git pull",
+		Stderr:   "There is no tracking information for the current branch.\nPlease specify which branch you want to merge with.\nSee git-pull(1) for details.\n\n    git pull <remote> <branch>\n\nIf you wish to set tracking information for this branch you can do so with:\n\n    git branch --set-upstream-to=<remote>/<branch> 0426-yuluo/fix\n",
+		ExitCode: 1,
+	})
+	if result.Fixed {
+		t.Fatalf("Expected placeholder upstream to stay unchanged, got %+v", result)
+	}
+}
+
+func TestEngine_FixWithParser_PushNoUpstreamTargetsPushOnly(t *testing.T) {
+	eng := NewEngine(WithParser(parser.NewRegistry()))
+	stderr := "fatal: The current branch feature/topic has no upstream branch.\n" +
+		"To push the current branch and set the remote as upstream, use\n\n" +
+		"    git push --set-upstream origin feature/topic\n"
+
+	result := eng.FixWithContext(itypes.ParserContext{
+		Command:  "git status && sudo git push",
+		Stderr:   stderr,
+		ExitCode: 128,
 	})
 	if !result.Fixed {
-		t.Fatal("Expected placeholder remote to default to origin")
+		t.Fatal("Expected push command to be fixed")
 	}
-	if result.Command != "git remove -v && git pull --set-upstream origin 0426-yuluo/fix" {
-		t.Fatalf("Expected placeholder remote to default to origin, got %q", result.Command)
+	if result.Command != "git status && sudo git push --set-upstream origin feature/topic" {
+		t.Fatalf("Expected upstream fix to preserve the compound wrapper, got %q", result.Command)
+	}
+}
+
+func TestEngine_FixWithParser_RejectsAmbiguousCompoundTargets(t *testing.T) {
+	eng := NewEngine(WithParser(parser.NewRegistry()))
+	stderr := "fatal: The current branch feature/topic has no upstream branch.\n" +
+		"To push the current branch and set the remote as upstream, use\n\n" +
+		"    git push --set-upstream origin feature/topic\n"
+
+	result := eng.FixWithContext(itypes.ParserContext{
+		Command:  "git push && git -C other push",
+		Stderr:   stderr,
+		ExitCode: 128,
+	})
+	if result.Fixed {
+		t.Fatalf("Expected ambiguous parser targets to stay unchanged, got %+v", result)
 	}
 }
 
@@ -244,8 +332,9 @@ func TestEngine_FixWithParser_DivergentPullRebaseTargetsPullOnly(t *testing.T) {
 	)
 
 	result := eng.FixWithContext(itypes.ParserContext{
-		Command: "git status && git pull origin main",
-		Stderr:  "hint: You have divergent branches and need to specify how to reconcile them.\nhint: You can do so by running one of the following commands sometime before\nhint: your next pull:\nhint:\nhint:   git config pull.rebase false  # merge\nhint:   git config pull.rebase true   # rebase\nhint:   git config pull.ff only       # fast-forward only\nhint:\nhint: You can replace \"git config\" with \"git config --global\" to set a default\nhint: preference for all repositories. You can also pass --rebase, --no-rebase,\nhint: or --ff-only on the command line to override the configured default per\nhint: invocation.\nfatal: Need to specify how to reconcile divergent branches.\n",
+		Command:  "git status && git pull origin main",
+		Stderr:   "hint: You have divergent branches and need to specify how to reconcile them.\nhint: You can do so by running one of the following commands sometime before\nhint: your next pull:\nhint:\nhint:   git config pull.rebase false  # merge\nhint:   git config pull.rebase true   # rebase\nhint:   git config pull.ff only       # fast-forward only\nhint:\nhint: You can replace \"git config\" with \"git config --global\" to set a default\nhint: preference for all repositories. You can also pass --rebase, --no-rebase,\nhint: or --ff-only on the command line to override the configured default per\nhint: invocation.\nfatal: Need to specify how to reconcile divergent branches.\n",
+		ExitCode: 1,
 	})
 	if !result.Fixed {
 		t.Fatal("Expected divergent pull command to be fixed")
@@ -483,6 +572,45 @@ func TestEngine_Fix_PreservesQuotedArguments(t *testing.T) {
 	}
 	if result.Command != "git commit -m 'a   b'" {
 		t.Fatalf("Expected quoted argument spacing to be preserved, got %q", result.Command)
+	}
+}
+
+func TestEngine_Fix_PreservesUnclosedQuotedArguments(t *testing.T) {
+	eng := NewEngine(
+		WithCommands([]string{"git"}),
+		WithKeyboard(NewQWERTYKeyboard()),
+	)
+
+	for _, command := range []string{
+		"gut commit -m 'a   b",
+		`gut commit -m "a   b`,
+	} {
+		result := eng.Fix(command, "")
+		if !result.Fixed {
+			t.Fatalf("Expected unclosed quoted command %q to be fixed", command)
+		}
+		want := "git" + command[len("gut"):]
+		if result.Command != want {
+			t.Fatalf("Fix(%q).Command = %q, want byte-preserving %q", command, result.Command, want)
+		}
+	}
+}
+
+func TestEngine_Fix_SkipsInvalidRecoveredCompoundCall(t *testing.T) {
+	eng := NewEngine(
+		WithCommands([]string{"git", "docker"}),
+		WithKeyboard(NewQWERTYKeyboard()),
+	)
+
+	for _, command := range []string{
+		"gti status && 'dcoker ps",
+		`gti status && "dcoker ps`,
+	} {
+		result := eng.Fix(command, "")
+		want := "git" + command[len("gti"):]
+		if !result.Fixed || result.Command != want {
+			t.Fatalf("Fix(%q) = %+v, want byte-preserving %q", command, result, want)
+		}
 	}
 }
 
@@ -924,6 +1052,41 @@ func TestEngine_MaybeAutoLearnFromHistory_RespectsContextDeadline(t *testing.T) 
 	}
 	if _, ok := rules.MatchUser("mytypo"); ok {
 		t.Fatal("Expected expired context to skip user rule creation")
+	}
+}
+
+func TestEngine_MaybeAutoLearnFromHistory_RollsBackRuleWhenHistorySaveFails(t *testing.T) {
+	history := NewHistory(t.TempDir())
+	rulesDir := t.TempDir()
+	rules := NewRules(rulesDir)
+	eng := NewEngine(
+		WithHistory(history),
+		WithRules(rules),
+		WithAutoLearnThreshold(1),
+	)
+
+	if err := history.Record("mytypo", "mytool"); err != nil {
+		t.Fatalf("Record failed: %v", err)
+	}
+	blocker := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blocker, []byte("block"), 0600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	history.configDir = blocker
+
+	result := eng.maybeAutoLearnFromHistory(context.Background(), "mytypo", "mytool")
+	if !result.Triggered || result.Persisted || result.Err == nil {
+		t.Fatalf("maybeAutoLearnFromHistory() = %+v", result)
+	}
+	if _, ok := rules.MatchUser("mytypo"); ok {
+		t.Fatal("failed auto-learn kept the new rule in memory")
+	}
+	if _, ok := NewRules(rulesDir).MatchUser("mytypo"); ok {
+		t.Fatal("failed auto-learn kept the new rule on disk")
+	}
+	entry, ok := history.Lookup("mytypo")
+	if !ok || entry.RuleApplied {
+		t.Fatalf("failed auto-learn changed history: %+v, ok=%v", entry, ok)
 	}
 }
 
@@ -1543,6 +1706,7 @@ func TestEngine_FixWithAliasContextParser(t *testing.T) {
 	got := eng.FixWithContext(itypes.ParserContext{
 		Command:      "g remove -v",
 		Stderr:       "git: 'remove' is not a git command.\n\nThe most similar command is\n\tremote\n",
+		ExitCode:     1,
 		AliasContext: []itypes.AliasContextEntry{{Shell: "bash", Kind: "alias", Name: "g", Expansion: "git"}},
 	})
 	if !got.Fixed || got.Command != "g remote -v" || !got.UsedParser {

--- a/internal/engine/fix_pipeline.go
+++ b/internal/engine/fix_pipeline.go
@@ -12,8 +12,9 @@ import (
 // stderr is optional and used for error parsing.
 func (e *Engine) Fix(cmd, stderr string) itypes.FixResult {
 	return e.FixWithContext(itypes.ParserContext{
-		Command: cmd,
-		Stderr:  stderr,
+		Command:  cmd,
+		Stderr:   stderr,
+		ExitCode: -1,
 	})
 }
 
@@ -126,8 +127,8 @@ func (e *Engine) fixWithoutAliasContext(input itypes.ParserContext) itypes.FixRe
 func (e *Engine) fixOnePass(input itypes.ParserContext) itypes.FixResult {
 	cmd := input.Command
 
-	// 1. Try error parser first (if stderr provided)
-	if input.Stderr != "" {
+	// 1. 仅在 stderr 非空且命令未成功时尝试错误解析器，-1 表示退出码未知。
+	if input.Stderr != "" && input.ExitCode != 0 {
 		if result := e.tryParser(input); isMeaningfulFix(cmd, result) {
 			return result
 		}

--- a/internal/engine/fix_pipeline.go
+++ b/internal/engine/fix_pipeline.go
@@ -127,7 +127,7 @@ func (e *Engine) fixWithoutAliasContext(input itypes.ParserContext) itypes.FixRe
 func (e *Engine) fixOnePass(input itypes.ParserContext) itypes.FixResult {
 	cmd := input.Command
 
-	// 1. 仅在 stderr 非空且命令未成功时尝试错误解析器，-1 表示退出码未知。
+	// 1. Try error parsers only when stderr is present and the command did not succeed; -1 means the exit code is unknown.
 	if input.Stderr != "" && input.ExitCode != 0 {
 		if result := e.tryParser(input); isMeaningfulFix(cmd, result) {
 			return result

--- a/internal/engine/rules.go
+++ b/internal/engine/rules.go
@@ -3,8 +3,10 @@ package engine
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/yuluo-yx/typo/internal/storage"
@@ -95,6 +97,12 @@ func (r *Rules) MatchBuiltin(cmd string) (itypes.Rule, bool) {
 
 // AddUserRule adds a new user rule.
 func (r *Rules) AddUserRule(rule itypes.Rule) error {
+	normalized, err := normalizeUserRule(rule)
+	if err != nil {
+		return err
+	}
+	rule = normalized
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -114,8 +122,27 @@ func (r *Rules) AddUserRule(rule itypes.Rule) error {
 	return nil
 }
 
+func normalizeUserRule(rule itypes.Rule) (itypes.Rule, error) {
+	rule.From = strings.TrimSpace(rule.From)
+	rule.To = strings.TrimSpace(rule.To)
+
+	if rule.From == "" {
+		return itypes.Rule{}, errors.New("rule source must not be empty")
+	}
+	if rule.To == "" {
+		return itypes.Rule{}, errors.New("rule target must not be empty")
+	}
+	if rule.From == rule.To {
+		return itypes.Rule{}, errors.New("rule source and target must differ")
+	}
+
+	return rule, nil
+}
+
 // RemoveUserRule removes a user rule.
 func (r *Rules) RemoveUserRule(from string) error {
+	from = strings.TrimSpace(from)
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -460,6 +487,12 @@ func (r *Rules) loadUserRules() {
 	}
 
 	for _, rule := range userRules {
+		normalized, err := normalizeUserRule(rule)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "typo: ignoring invalid user rule in %s: %v\n", rulesFile, err)
+			continue
+		}
+		rule = normalized
 		rule.Enable = true
 		r.user[rule.From] = rule
 	}

--- a/internal/engine/rules_test.go
+++ b/internal/engine/rules_test.go
@@ -97,6 +97,44 @@ func TestRules_AddUserRule(t *testing.T) {
 	}
 }
 
+func TestRules_AddUserRuleValidatesAndNormalizes(t *testing.T) {
+	t.Run("normalizes surrounding whitespace", func(t *testing.T) {
+		r := NewRules(t.TempDir())
+		if err := r.AddUserRule(itypes.Rule{From: "  typo  ", To: "  command  "}); err != nil {
+			t.Fatalf("AddUserRule failed: %v", err)
+		}
+
+		rule, ok := r.MatchUser("typo")
+		if !ok || rule.From != "typo" || rule.To != "command" {
+			t.Fatalf("normalized rule = %+v, ok=%v", rule, ok)
+		}
+	})
+
+	tests := []struct {
+		name string
+		rule itypes.Rule
+	}{
+		{name: "empty source", rule: itypes.Rule{To: "command"}},
+		{name: "blank source", rule: itypes.Rule{From: " \t ", To: "command"}},
+		{name: "empty target", rule: itypes.Rule{From: "typo"}},
+		{name: "blank target", rule: itypes.Rule{From: "typo", To: " \n "}},
+		{name: "same pair", rule: itypes.Rule{From: "same", To: "same"}},
+		{name: "same after normalization", rule: itypes.Rule{From: " same ", To: "same"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewRules(t.TempDir())
+			if err := r.AddUserRule(tt.rule); err == nil {
+				t.Fatal("AddUserRule accepted an invalid rule")
+			}
+			if len(r.user) != 0 {
+				t.Fatalf("invalid rule mutated user rules: %+v", r.user)
+			}
+		})
+	}
+}
+
 func TestRules_RemoveUserRule(t *testing.T) {
 	tmpDir := t.TempDir()
 	r := NewRules(tmpDir)
@@ -107,7 +145,7 @@ func TestRules_RemoveUserRule(t *testing.T) {
 		t.Fatalf("AddUserRule failed: %v", err)
 	}
 
-	if err := r.RemoveUserRule("testcmd"); err != nil {
+	if err := r.RemoveUserRule("  testcmd  "); err != nil {
 		t.Fatalf("RemoveUserRule failed: %v", err)
 	}
 
@@ -232,7 +270,7 @@ func TestRules_EmptyConfigDir(t *testing.T) {
 	}
 
 	// AddUserRule should not error with empty config dir
-	err := r.AddUserRule(itypes.Rule{From: "test", To: "test"})
+	err := r.AddUserRule(itypes.Rule{From: "test", To: "correct"})
 	if err != nil {
 		t.Errorf("AddUserRule should not error with empty config dir: %v", err)
 	}
@@ -292,6 +330,40 @@ func TestRules_LoadInvalidJSON(t *testing.T) {
 	}
 	if len(matches) != 1 {
 		t.Fatalf("Expected one quarantined rules file, got %v", matches)
+	}
+}
+
+func TestRules_LoadSkipsInvalidEntriesAndKeepsValidRules(t *testing.T) {
+	tmpDir := t.TempDir()
+	rulesFile := filepath.Join(tmpDir, "rules.json")
+	data := []byte(`[
+  {"from":" valid ","to":" target "},
+  {"from":"","to":"empty-source"},
+  {"from":"empty-target","to":"   "},
+  {"from":" same ","to":"same"}
+]`)
+	if err := os.WriteFile(rulesFile, data, 0600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	r := NewRules(tmpDir)
+	rule, ok := r.MatchUser("valid")
+	if !ok || rule.From != "valid" || rule.To != "target" {
+		t.Fatalf("valid rule was not normalized and loaded: %+v, ok=%v", rule, ok)
+	}
+	if len(r.user) != 1 {
+		t.Fatalf("loaded invalid rules: %+v", r.user)
+	}
+
+	matches, err := filepath.Glob(rulesFile + ".corrupt-*")
+	if err != nil {
+		t.Fatalf("Glob failed: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("semantic errors should not quarantine the complete file: %v", matches)
+	}
+	if _, err := os.Stat(rulesFile); err != nil {
+		t.Fatalf("rules file should remain in place: %v", err)
 	}
 }
 

--- a/internal/engine/shell.go
+++ b/internal/engine/shell.go
@@ -23,7 +23,8 @@ type shellWordReplacement struct {
 }
 
 func parseShellCommandLines(raw string) ([]*shellCommandLine, error) {
-	parser := syntax.NewParser(syntax.Variant(syntax.LangBash))
+	// 交互输入可能尚未闭合，恢复一个语法错误以保留原始词范围。
+	parser := syntax.NewParser(syntax.Variant(syntax.LangBash), syntax.RecoverErrors(1))
 	file, err := parser.Parse(strings.NewReader(raw+"\n"), "")
 	if err != nil {
 		return nil, err
@@ -42,7 +43,7 @@ func parseShellCommandLines(raw string) ([]*shellCommandLine, error) {
 		}
 
 		commandIdx := findExecutableArgIndex(call.Args)
-		if commandIdx == -1 {
+		if commandIdx == -1 || !shellWordRangesValid(call.Args, len(raw)) {
 			return true
 		}
 
@@ -65,6 +66,19 @@ func parseShellCommandLines(raw string) ([]*shellCommandLine, error) {
 	})
 
 	return lines, nil
+}
+
+func shellWordRangesValid(args []*syntax.Word, rawLen int) bool {
+	for _, arg := range args {
+		if arg.Pos().IsRecovered() || arg.End().IsRecovered() {
+			return false
+		}
+		start, end := utils.ShellNodeRange(arg, rawLen)
+		if start > end {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *shellCommandLine) commandWord() string {
@@ -177,6 +191,9 @@ func findExecutableArgIndex(args []*syntax.Word) int {
 		word := args[idx].Lit()
 		switch word {
 		case "builtin", "nocorrect", "noglob":
+			idx++
+		// Fish 作业装饰器后的词才是实际命令。
+		case "and", "or", "not":
 			idx++
 		case "command":
 			idx++

--- a/internal/engine/shell.go
+++ b/internal/engine/shell.go
@@ -23,7 +23,7 @@ type shellWordReplacement struct {
 }
 
 func parseShellCommandLines(raw string) ([]*shellCommandLine, error) {
-	// 交互输入可能尚未闭合，恢复一个语法错误以保留原始词范围。
+	// Interactive input may be incomplete; recover one syntax error to preserve original word ranges.
 	parser := syntax.NewParser(syntax.Variant(syntax.LangBash), syntax.RecoverErrors(1))
 	file, err := parser.Parse(strings.NewReader(raw+"\n"), "")
 	if err != nil {
@@ -192,7 +192,7 @@ func findExecutableArgIndex(args []*syntax.Word) int {
 		switch word {
 		case "builtin", "nocorrect", "noglob":
 			idx++
-		// Fish 作业装饰器后的词才是实际命令。
+		// The word after a Fish job decorator is the actual command.
 		case "and", "or", "not":
 			idx++
 		case "command":

--- a/internal/engine/shell_test.go
+++ b/internal/engine/shell_test.go
@@ -58,6 +58,21 @@ func TestParseShellCommandLines_UnsupportedShape(t *testing.T) {
 	}
 }
 
+func TestParseShellCommandLines_SkipsInvalidRecoveredCalls(t *testing.T) {
+	for _, raw := range []string{
+		"gti status && 'dcoker ps",
+		`gti status && "dcoker ps`,
+	} {
+		lines, err := parseShellCommandLines(raw)
+		if err != nil {
+			t.Fatalf("parseShellCommandLines(%q) failed: %v", raw, err)
+		}
+		if len(lines) != 1 || lines[0].commandWord() != "gti" {
+			t.Fatalf("parseShellCommandLines(%q) = %+v, want only the valid first call", raw, lines)
+		}
+	}
+}
+
 func TestFindExecutableArgIndex_Wrappers(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -68,6 +83,9 @@ func TestFindExecutableArgIndex_Wrappers(t *testing.T) {
 		{name: "builtin wrapper", raw: "builtin echo ok", wantIdx: 1, wantWord: "echo"},
 		{name: "nocorrect wrapper", raw: "nocorrect gut status", wantIdx: 1, wantWord: "gut"},
 		{name: "noglob wrapper", raw: "noglob gerp main file", wantIdx: 1, wantWord: "gerp"},
+		{name: "fish and decorator", raw: "and dcoker ps", wantIdx: 1, wantWord: "dcoker"},
+		{name: "fish or decorator", raw: "or dcoker ps", wantIdx: 1, wantWord: "dcoker"},
+		{name: "fish not decorator", raw: "not gti status", wantIdx: 1, wantWord: "gti"},
 		{name: "command wrapper option", raw: "command -p gti status", wantIdx: 2, wantWord: "gti"},
 		{name: "command wrapper multiple options", raw: "command -p -v git", wantIdx: 3, wantWord: "git"},
 		{name: "env wrapper with assignments", raw: "env --unset HOME FOO=1 gti status", wantIdx: 4, wantWord: "gti"},

--- a/internal/parser/docker.go
+++ b/internal/parser/docker.go
@@ -40,16 +40,13 @@ func (p *DockerParser) Parse(ctx itypes.ParserContext) itypes.ParserResult {
 	if len(matches) >= 3 {
 		wrongCmd := matches[1]
 		suggested := matches[2]
-		fixed := ""
 		call, err := parseShellCall(cmd)
 		if err != nil {
-			fixed = strings.Replace(cmd, wrongCmd, suggested, 1)
-		} else {
-			var ok bool
-			fixed, ok = call.replaceSubcommand(parserNameDocker, wrongCmd, suggested, dockerParserOptionsWithValues)
-			if !ok {
-				return itypes.ParserResult{Fixed: false}
-			}
+			return itypes.ParserResult{Fixed: false}
+		}
+		fixed, ok := call.replaceSubcommand(parserNameDocker, wrongCmd, suggested, dockerParserOptionsWithValues)
+		if !ok {
+			return itypes.ParserResult{Fixed: false}
 		}
 		return itypes.ParserResult{
 			Fixed:   true,
@@ -63,16 +60,13 @@ func (p *DockerParser) Parse(ctx itypes.ParserContext) itypes.ParserResult {
 	if len(matches) >= 3 {
 		wrongCmd := matches[1]
 		suggested := matches[2]
-		fixed := ""
 		call, err := parseShellCall(cmd)
 		if err != nil {
-			fixed = strings.Replace(cmd, wrongCmd, suggested, 1)
-		} else {
-			var ok bool
-			fixed, ok = call.replaceSubcommand(parserNameDocker, wrongCmd, suggested, dockerParserOptionsWithValues)
-			if !ok {
-				return itypes.ParserResult{Fixed: false}
-			}
+			return itypes.ParserResult{Fixed: false}
+		}
+		fixed, ok := call.replaceSubcommand(parserNameDocker, wrongCmd, suggested, dockerParserOptionsWithValues)
+		if !ok {
+			return itypes.ParserResult{Fixed: false}
 		}
 		return itypes.ParserResult{
 			Fixed:   true,

--- a/internal/parser/generic.go
+++ b/internal/parser/generic.go
@@ -64,8 +64,6 @@ func (p *GenericParser) Parse(ctx itypes.ParserContext) itypes.ParserResult {
 	if strings.HasPrefix(suggested, "-") {
 		return itypes.ParserResult{Fixed: false}
 	}
-	wrong := p.extractWrongCommand(stderr)
-
 	parts := strings.Fields(cmd)
 	if len(parts) < 2 {
 		return itypes.ParserResult{Fixed: false}
@@ -74,29 +72,10 @@ func (p *GenericParser) Parse(ctx itypes.ParserContext) itypes.ParserResult {
 
 	call, err := parseShellCall(cmd)
 	if err != nil {
-		if wrong != "" {
-			fixed := strings.Replace(cmd, wrong, suggested, 1)
-			if fixed != cmd {
-				return itypes.ParserResult{
-					Fixed:   true,
-					Command: fixed,
-					Message: "generic suggested: " + suggested,
-				}
-			}
-		}
-
-		// Fallback: reconstruct as "binary suggestion [rest...]".
-		fixed := binary + " " + suggested
-		if len(parts) > 2 {
-			fixed += " " + strings.Join(parts[2:], " ")
-		}
-		return itypes.ParserResult{
-			Fixed:   true,
-			Command: fixed,
-			Message: "generic suggested: " + suggested,
-		}
+		return itypes.ParserResult{Fixed: false}
 	}
 
+	wrong := p.extractWrongCommand(stderr)
 	fixed := ""
 	ok := false
 	if wrong != "" {

--- a/internal/parser/git.go
+++ b/internal/parser/git.go
@@ -13,26 +13,24 @@ import (
 // GitParser parses git command errors.
 type GitParser struct {
 	didYouMeanRegex          *regexp.Regexp
-	noUpstreamRegex          *regexp.Regexp
-	legacyUpstreamRegex      *regexp.Regexp
+	pushNoUpstreamFatalRegex *regexp.Regexp
+	pushNoUpstreamRegex      *regexp.Regexp
 	divergentBranchesRegex   *regexp.Regexp
 	reconcileDivergenceRegex *regexp.Regexp
-	pushRejectedRegex        *regexp.Regexp
-	pushNeedsPullRegex       *regexp.Regexp
 	placeholderRegex         *regexp.Regexp
 	notGitRepoRegex          *regexp.Regexp
 }
+
+var gitUpstreamTokenRegex = regexp.MustCompile(`^[A-Za-z0-9._][A-Za-z0-9._/@+-]*$`)
 
 // NewGitParser creates a new GitParser.
 func NewGitParser() *GitParser {
 	return &GitParser{
 		didYouMeanRegex:          regexp.MustCompile(`(?s)git: '([^']+)' is not a git command\..*The most similar commands? (?:is|are)\s+(\w+)`),
-		noUpstreamRegex:          regexp.MustCompile(`git branch --set-upstream-to(?:=|\s+)([^\s]+)(?:\s+([^\s]+))?`),
-		legacyUpstreamRegex:      regexp.MustCompile(`git branch --set-upstream\s+([^\s]+)\s+([^\s]+)`),
+		pushNoUpstreamFatalRegex: regexp.MustCompile(`(?m)^fatal: The current branch ([^\s]+) has no upstream branch\.[\t\r ]*$`),
+		pushNoUpstreamRegex:      regexp.MustCompile(`(?m)^[ \t]*git push (?:-u|--set-upstream)[ \t]+([^\s]+)[ \t]+([^\s]+)[ \t\r]*$`),
 		divergentBranchesRegex:   regexp.MustCompile(`(?i)You have divergent branches and need to specify how to reconcile them\.`),
 		reconcileDivergenceRegex: regexp.MustCompile(`(?i)fatal: Need to specify how to reconcile divergent branches\.`),
-		pushRejectedRegex:        regexp.MustCompile(`(?i)(?:fetch first|non-fast-forward)`),
-		pushNeedsPullRegex:       regexp.MustCompile(`(?is)(?:git pull|integrate the remote changes|before pushing again)`),
 		placeholderRegex:         regexp.MustCompile(`^<[^>\s]+>$`),
 		notGitRepoRegex:          regexp.MustCompile(`fatal: not a git repository`),
 	}
@@ -58,16 +56,11 @@ func (p *GitParser) Parse(ctx itypes.ParserContext) itypes.ParserResult {
 		return result
 	}
 
-	// Try to parse "no upstream" errors
-	if result := p.parseNoUpstream(cmd, stderr); result.Fixed {
+	if result := p.parsePushNoUpstream(cmd, stderr); result.Fixed {
 		return result
 	}
 
 	if result := p.parseDivergentPullRebase(cmd, stderr); result.Fixed {
-		return result
-	}
-
-	if result := p.parsePushRejectedNeedsPull(cmd, stderr); result.Fixed {
 		return result
 	}
 
@@ -82,16 +75,10 @@ func (p *GitParser) parseDidYouMean(cmd, stderr string) itypes.ParserResult {
 
 	wrongCmd := matches[1]
 	suggested := matches[2]
-	fixed := ""
 
 	call, err := parseShellCall(cmd)
 	if err != nil {
-		fixed = strings.Replace(cmd, wrongCmd, suggested, 1)
-		return itypes.ParserResult{
-			Fixed:   true,
-			Command: fixed,
-			Message: "git suggested: " + suggested,
-		}
+		return itypes.ParserResult{Fixed: false}
 	}
 
 	fixed, ok := call.replaceSubcommand(parserNameGit, wrongCmd, suggested, gitParserOptionsWithValues)
@@ -106,63 +93,86 @@ func (p *GitParser) parseDidYouMean(cmd, stderr string) itypes.ParserResult {
 	}
 }
 
-func (p *GitParser) parseNoUpstream(cmd, stderr string) itypes.ParserResult {
-	if gitSubcommand(cmd) != "pull" || gitCommandHasUpstreamFlag(cmd) {
+func (p *GitParser) parsePushNoUpstream(cmd, stderr string) itypes.ParserResult {
+	if gitSubcommand(cmd) != "push" || gitCommandHasUpstreamFlag(cmd) {
 		return itypes.ParserResult{Fixed: false}
 	}
 
-	remote, branch, ok := p.parseUpstreamHint(stderr)
+	remote, branch, ok := p.parsePushUpstreamHint(stderr)
 	if !ok {
 		return itypes.ParserResult{Fixed: false}
 	}
 
-	// Add --set-upstream flag to the command
+	fixed, ok := addGitPushUpstream(cmd, remote, branch)
+	if !ok {
+		return itypes.ParserResult{Fixed: false}
+	}
+
 	return itypes.ParserResult{
 		Fixed:   true,
-		Command: cmd + " --set-upstream " + remote + " " + branch,
-		Message: "adding upstream tracking: " + remote + "/" + branch,
+		Command: fixed,
+		Message: "adding push upstream tracking: " + remote + "/" + branch,
 	}
 }
 
-func (p *GitParser) parseUpstreamHint(stderr string) (string, string, bool) {
-	matches := p.noUpstreamRegex.FindStringSubmatch(stderr)
-	if len(matches) >= 2 {
-		localBranch := ""
-		if len(matches) >= 3 {
-			localBranch = matches[2]
-		}
-		return p.parseUpstreamTarget(matches[1], localBranch)
-	}
-
-	matches = p.legacyUpstreamRegex.FindStringSubmatch(stderr)
-	if len(matches) >= 3 {
-		localBranch := matches[1]
-		upstreamTarget := matches[2]
-		return p.parseUpstreamTarget(upstreamTarget, localBranch)
-	}
-
-	return "", "", false
-}
-
-func (p *GitParser) parseUpstreamTarget(target, localBranch string) (string, string, bool) {
-	remote, upstreamBranch, ok := strings.Cut(target, "/")
-	if !ok {
+func (p *GitParser) parsePushUpstreamHint(stderr string) (string, string, bool) {
+	fatalMatches := p.pushNoUpstreamFatalRegex.FindStringSubmatch(stderr)
+	matches := p.pushNoUpstreamRegex.FindStringSubmatch(stderr)
+	if len(fatalMatches) < 2 || len(matches) < 3 || fatalMatches[1] != matches[2] {
 		return "", "", false
 	}
+	return p.validateUpstreamTarget(matches[1], matches[2])
+}
 
-	if p.placeholderRegex.MatchString(remote) {
-		remote = "origin"
+func (p *GitParser) validateUpstreamTarget(remote, branch string) (string, string, bool) {
+	if remote == "" || branch == "" || strings.HasPrefix(remote, "-") || strings.HasPrefix(branch, "-") {
+		return "", "", false
 	}
-
-	branch := upstreamBranch
-	if p.placeholderRegex.MatchString(branch) && localBranch != "" {
-		branch = localBranch
+	if p.placeholderRegex.MatchString(remote) || p.placeholderRegex.MatchString(branch) {
+		return "", "", false
 	}
-	if p.placeholderRegex.MatchString(branch) {
+	if !gitUpstreamTokenRegex.MatchString(remote) || !gitUpstreamTokenRegex.MatchString(branch) {
 		return "", "", false
 	}
 
 	return remote, branch, true
+}
+
+func addGitPushUpstream(cmd, remote, branch string) (string, bool) {
+	if !gitUpstreamTokenRegex.MatchString(remote) || !gitUpstreamTokenRegex.MatchString(branch) {
+		return "", false
+	}
+	call, err := parseShellCall(cmd)
+	if err != nil || len(call.args) == 0 {
+		return "", false
+	}
+	insertion := " --set-upstream " + remote + " " + branch
+	if gitPrefixedSubcommand(call.args[0].Lit()) == "push" {
+		if !gitPushUpstreamArgsAllowed(gitShellArgsLits(call.args[1:])) {
+			return "", false
+		}
+		return call.insertAfterWord(len(call.args)-1, insertion), true
+	}
+
+	index := findShellSubcommandIndex(call.args, parserNameGit, gitParserOptionsWithValues)
+	if index == -1 || call.args[index].Lit() != "push" ||
+		!gitPushUpstreamArgsAllowed(gitShellArgsLits(call.args[index+1:])) {
+		return "", false
+	}
+	return call.insertAfterWord(len(call.args)-1, insertion), true
+}
+
+func gitPushUpstreamArgsAllowed(args []string) bool {
+	for _, arg := range args {
+		switch arg {
+		case "-v", "--verbose", "--no-verbose", "-q", "--quiet", "--no-quiet", "--progress", "--no-progress":
+			continue
+		case "-n", "--dry-run", "--no-dry-run", "--porcelain", "--no-porcelain":
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func (p *GitParser) parseDivergentPullRebase(cmd, stderr string) itypes.ParserResult {
@@ -185,28 +195,12 @@ func (p *GitParser) parseDivergentPullRebase(cmd, stderr string) itypes.ParserRe
 	}
 }
 
-func (p *GitParser) parsePushRejectedNeedsPull(cmd, stderr string) itypes.ParserResult {
-	if gitSubcommand(cmd) != "push" {
-		return itypes.ParserResult{Fixed: false}
-	}
-	if !p.pushRejectedRegex.MatchString(stderr) || !p.pushNeedsPullRegex.MatchString(stderr) {
-		return itypes.ParserResult{Fixed: false}
-	}
-
-	fixed, ok := replaceGitPushWithPull(cmd)
-	if !ok {
-		return itypes.ParserResult{Fixed: false}
-	}
-
-	return itypes.ParserResult{
-		Fixed:   true,
-		Command: fixed,
-		Message: "retry after integrating remote changes with git pull",
-	}
+func gitSubcommand(cmd string) string {
+	parts := shellCommandWords(cmd)
+	return gitSubcommandFromWords(parts)
 }
 
-func gitSubcommand(cmd string) string {
-	parts := strings.Fields(cmd)
+func gitSubcommandFromWords(parts []string) string {
 	if len(parts) == 0 {
 		return ""
 	}
@@ -240,6 +234,14 @@ func gitSubcommand(cmd string) string {
 	}
 
 	return ""
+}
+
+func shellCommandWords(cmd string) []string {
+	call, err := parseShellCall(cmd)
+	if err == nil {
+		return gitShellArgsLits(call.args)
+	}
+	return strings.Fields(cmd)
 }
 
 func gitPrefixedSubcommand(first string) string {
@@ -297,7 +299,7 @@ func gitShortOptionState(arg string) gitOptionParseState {
 }
 
 func gitCommandHasUpstreamFlag(cmd string) bool {
-	for _, part := range strings.Fields(cmd) {
+	for _, part := range shellCommandWords(cmd) {
 		switch {
 		case part == "--set-upstream", part == "--set-upstream-to":
 			return true
@@ -310,7 +312,7 @@ func gitCommandHasUpstreamFlag(cmd string) bool {
 }
 
 func gitCommandHasPullReconcileFlag(cmd string) bool {
-	for _, part := range strings.Fields(cmd) {
+	for _, part := range shellCommandWords(cmd) {
 		switch {
 		case part == "--rebase", part == "--no-rebase", part == "--ff-only":
 			return true
@@ -322,63 +324,6 @@ func gitCommandHasPullReconcileFlag(cmd string) bool {
 	return false
 }
 
-func replaceGitPushWithPull(cmd string) (string, bool) {
-	parts := strings.Fields(cmd)
-	if len(parts) == 0 {
-		return "", false
-	}
-
-	if gitPrefixedSubcommand(parts[0]) == "push" {
-		return replaceGitPrefixedPushWithPull(cmd)
-	}
-
-	call, err := parseShellCall(cmd)
-	if err == nil {
-		index := findShellSubcommandIndex(call.args, parserNameGit, gitParserOptionsWithValues)
-		if index != -1 && call.args[index].Lit() == "push" {
-			if gitPushArgsBlockPull(gitShellArgsLits(call.args[index+1:])) {
-				return "", false
-			}
-			fixed := call.replaceWord(index, "pull")
-			return normalizeGitPullFromPush(fixed)
-		}
-	}
-
-	for i, part := range parts {
-		if part != "push" {
-			continue
-		}
-		if gitPushArgsBlockPull(parts[i+1:]) {
-			return "", false
-		}
-		parts[i] = "pull"
-		return normalizeGitPullFields(parts), true
-	}
-
-	return "", false
-}
-
-func replaceGitPrefixedPushWithPull(cmd string) (string, bool) {
-	call, err := parseShellCall(cmd)
-	if err == nil && len(call.args) > 0 && gitPrefixedSubcommand(call.args[0].Lit()) == "push" {
-		if gitPushArgsBlockPull(gitShellArgsLits(call.args[1:])) {
-			return "", false
-		}
-		fixed := call.replaceWord(0, gitCommandPrefix+"pull")
-		return normalizeGitPullFromPush(fixed)
-	}
-
-	parts := strings.Fields(cmd)
-	if len(parts) == 0 || gitPrefixedSubcommand(parts[0]) != "push" {
-		return "", false
-	}
-	if gitPushArgsBlockPull(parts[1:]) {
-		return "", false
-	}
-	parts[0] = gitCommandPrefix + "pull"
-	return normalizeGitPullFields(parts), true
-}
-
 func gitShellArgsLits(args []*syntax.Word) []string {
 	lits := make([]string, 0, len(args))
 	for _, arg := range args {
@@ -387,110 +332,22 @@ func gitShellArgsLits(args []*syntax.Word) []string {
 	return lits
 }
 
-func gitPushArgsBlockPull(args []string) bool {
-	for _, arg := range args {
-		if arg == "--" {
-			return true
-		}
-		if strings.Contains(arg, ":") {
-			return true
-		}
-		if !strings.HasPrefix(arg, "-") || arg == "-" {
-			continue
-		}
-		if gitPushOptionAllowedForPull(arg) {
-			continue
-		}
-		return true
-	}
-
-	return false
-}
-
-func gitPushOptionAllowedForPull(arg string) bool {
-	switch {
-	case arg == "-u":
-		return true
-	case arg == "-v", arg == "-q":
-		return true
-	case arg == "--set-upstream", arg == "--no-set-upstream":
-		return true
-	case strings.HasPrefix(arg, "--set-upstream="):
-		return true
-	case arg == "--verbose", arg == "--no-verbose":
-		return true
-	case arg == "--quiet", arg == "--no-quiet":
-		return true
-	case arg == "--progress", arg == "--no-progress":
-		return true
-	default:
-		return false
-	}
-}
-
-func normalizeGitPullFromPush(cmd string) (string, bool) {
-	call, err := parseShellCall(cmd)
-	if err == nil {
-		fixed := cmd
-		for i := len(call.args) - 1; i >= 0; i-- {
-			if call.args[i].Lit() != "-u" {
-				continue
-			}
-			start, end := utils.ShellNodeRange(call.args[i], len(cmd))
-			fixed = fixed[:start] + "--set-upstream" + fixed[end:]
-		}
-		return fixed, true
-	}
-
-	return normalizeGitPullFields(strings.Fields(cmd)), true
-}
-
-func normalizeGitPullFields(parts []string) string {
-	for i, part := range parts {
-		if part == "-u" {
-			parts[i] = "--set-upstream"
-		}
-	}
-	return strings.Join(parts, " ")
-}
-
 func addGitPullRebaseFlag(cmd string) (string, bool) {
-	if strings.HasPrefix(strings.Fields(cmd)[0], gitCommandPrefix+"pull") {
-		return addGitPrefixedPullRebaseFlag(cmd)
-	}
-
 	call, err := parseShellCall(cmd)
-	if err == nil {
-		index := findShellSubcommandIndex(call.args, parserNameGit, gitParserOptionsWithValues)
-		if index != -1 && call.args[index].Lit() == "pull" {
-			return call.insertAfterWord(index, " --rebase"), true
-		}
-	}
-
-	parts := strings.Fields(cmd)
-	for i, part := range parts {
-		if part == "pull" {
-			parts = append(parts[:i+1], append([]string{"--rebase"}, parts[i+1:]...)...)
-			return strings.Join(parts, " "), true
-		}
-	}
-
-	return "", false
-}
-
-func addGitPrefixedPullRebaseFlag(cmd string) (string, bool) {
-	call, err := parseShellCall(cmd)
-	if err == nil && len(call.args) > 0 && gitPrefixedSubcommand(call.args[0].Lit()) == "pull" {
-		return call.insertAfterWord(0, " --rebase"), true
-	}
-
-	parts := strings.Fields(cmd)
-	if len(parts) == 0 || gitPrefixedSubcommand(parts[0]) != "pull" {
+	if err != nil || len(call.args) == 0 {
 		return "", false
 	}
 
-	parts = append(parts[:1], append([]string{"--rebase"}, parts[1:]...)...)
-	return strings.Join(parts, " "), true
+	if gitPrefixedSubcommand(call.args[0].Lit()) == "pull" {
+		return call.insertAfterWord(0, " --rebase"), true
+	}
+
+	index := findShellSubcommandIndex(call.args, parserNameGit, gitParserOptionsWithValues)
+	if index != -1 && call.args[index].Lit() == "pull" {
+		return call.insertAfterWord(index, " --rebase"), true
+	}
+
+	return "", false
 }
 
 var gitGlobalOptions = map[string]bool{

--- a/internal/parser/npm.go
+++ b/internal/parser/npm.go
@@ -43,16 +43,13 @@ func (p *NpmParser) Parse(ctx itypes.ParserContext) itypes.ParserResult {
 		suggestMatches := p.didYouMeanRegex.FindStringSubmatch(stderr)
 		if len(suggestMatches) >= 2 {
 			suggested := suggestMatches[1]
-			fixed := ""
 			call, err := parseShellCall(cmd)
 			if err != nil {
-				fixed = strings.Replace(cmd, wrongCmd, suggested, 1)
-			} else {
-				var ok bool
-				fixed, ok = call.replaceSubcommand(parserNameNPM, wrongCmd, suggested, npmParserOptionsWithValues)
-				if !ok {
-					return itypes.ParserResult{Fixed: false}
-				}
+				return itypes.ParserResult{Fixed: false}
+			}
+			fixed, ok := call.replaceSubcommand(parserNameNPM, wrongCmd, suggested, npmParserOptionsWithValues)
+			if !ok {
+				return itypes.ParserResult{Fixed: false}
 			}
 			return itypes.ParserResult{
 				Fixed:   true,
@@ -77,21 +74,6 @@ func (p *NpmParser) Parse(ctx itypes.ParserContext) itypes.ParserResult {
 				}
 			}
 			return itypes.ParserResult{Fixed: false}
-		}
-
-		// Fall back to the original permissive logic when shell parsing fails
-		// so interactive fixes still have a chance to recover.
-		parts := strings.Fields(cmd)
-		if len(parts) >= 2 {
-			fixed := parts[0] + " " + suggested
-			if len(parts) > 2 {
-				fixed += " " + strings.Join(parts[2:], " ")
-			}
-			return itypes.ParserResult{
-				Fixed:   true,
-				Command: fixed,
-				Message: "npm suggested: " + suggested,
-			}
 		}
 	}
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -54,39 +54,64 @@ func TestGitParser_Parse(t *testing.T) {
 			wantCmd: "git -c alias.remvoe=whatever remote -v",
 		},
 		{
-			name:    "no upstream branch",
+			name:    "pull upstream hint is not inferred",
 			cmd:     "git pull",
 			stderr:  "There is no tracking information for the current branch.\nPlease specify which branch you want to merge with.\nSee git-pull(1) for details.\n\n    git pull <remote> <branch>\n\nIf you wish to set tracking information for this branch, you can do so with:\n\n    git branch --set-upstream-to=origin/main main\n",
-			wantFix: true,
-			wantCmd: "git pull --set-upstream origin main",
+			wantFix: false,
 		},
 		{
-			name:    "no upstream branch with placeholder in upstream hint",
+			name:    "pull upstream hint with options is not inferred",
+			cmd:     "git pull --rebase --quiet",
+			stderr:  "There is no tracking information for the current branch.\n\n    git branch --set-upstream-to=origin/main main\n",
+			wantFix: false,
+		},
+		{
+			name:    "no upstream branch rejects placeholder branch",
 			cmd:     "git pull",
 			stderr:  "There is no tracking information for the current branch.\nPlease specify which branch you want to rebase against.\nSee git-pull(1) for details.\n\n    git pull <remote> <branch>\n\nIf you wish to set tracking information for this branch you can do so with:\n\n    git branch --set-upstream-to=origin/<branch> 0322-yuluo/inprove-add-check\n",
-			wantFix: true,
-			wantCmd: "git pull --set-upstream origin 0322-yuluo/inprove-add-check",
+			wantFix: false,
 		},
 		{
-			name:    "no upstream branch defaults placeholder remote to origin",
+			name:    "no upstream branch rejects placeholder remote and branch",
 			cmd:     "git pull",
 			stderr:  "There is no tracking information for the current branch.\nPlease specify which branch you want to merge with.\nSee git-pull(1) for details.\n\n    git pull <remote> <branch>\n\nIf you wish to set tracking information for this branch you can do so with:\n\n    git branch --set-upstream-to=<remote>/<branch> 0426-yuluo/fix\n",
-			wantFix: true,
-			wantCmd: "git pull --set-upstream origin 0426-yuluo/fix",
+			wantFix: false,
 		},
 		{
-			name:    "no upstream branch accepts spaced set upstream hint",
+			name:    "pull spaced set upstream hint is not inferred",
 			cmd:     "git pull",
 			stderr:  "There is no tracking information for the current branch.\nPlease specify which branch you want to merge with.\nSee git-pull(1) for details.\n\n    git pull <remote> <branch>\n\nIf you wish to set tracking information for this branch, you can do so with:\n\n    git branch --set-upstream-to origin/main main\n",
-			wantFix: true,
-			wantCmd: "git pull --set-upstream origin main",
+			wantFix: false,
 		},
 		{
-			name:    "no upstream branch accepts legacy set upstream hint",
+			name:    "pull legacy set upstream hint is not inferred",
 			cmd:     "git pull",
 			stderr:  "There is no tracking information for the current branch.\nPlease specify which branch you want to merge with.\nSee git-pull(1) for details.\n\n    git pull <remote> <branch>\n\nIf you wish to set tracking information for this branch, you can do so with:\n\n    git branch --set-upstream main origin/main\n",
-			wantFix: true,
-			wantCmd: "git pull --set-upstream origin main",
+			wantFix: false,
+		},
+		{
+			name:    "no upstream branch rejects cross shell metacharacters",
+			cmd:     "git pull",
+			stderr:  "There is no tracking information for the current branch.\n\n    git branch --set-upstream-to=origin/feature;touch${IFS}TYPO_PWNED feature;touch${IFS}TYPO_PWNED\n",
+			wantFix: false,
+		},
+		{
+			name:    "no upstream branch rejects unsafe remote characters",
+			cmd:     "git pull",
+			stderr:  "There is no tracking information for the current branch.\n\n    git branch --set-upstream-to=ori;gin/main main\n",
+			wantFix: false,
+		},
+		{
+			name:    "no upstream branch rejects ambiguous slash target with local branch",
+			cmd:     "git pull",
+			stderr:  "There is no tracking information for the current branch.\n\n    git branch --set-upstream-to=team/upstream/feature/topic feature/topic\n",
+			wantFix: false,
+		},
+		{
+			name:    "no upstream branch rejects ambiguous slash target",
+			cmd:     "git pull",
+			stderr:  "There is no tracking information for the current branch.\n\n    git branch --set-upstream-to=team/upstream/main\n",
+			wantFix: false,
 		},
 		{
 			name:    "no upstream branch is idempotent once fixed",
@@ -690,45 +715,53 @@ func TestParserShellHelpers_ParseFailures(t *testing.T) {
 	}
 }
 
-func TestGitDockerNpmParser_FallbackShellFailures(t *testing.T) {
+func TestCommandParsersRejectShellParseFailures(t *testing.T) {
 	gitResult := NewGitParser().Parse(itypes.ParserContext{
 		Command: "git remove '",
 		Stderr:  "git: 'remove' is not a git command. See 'git --help'.\n\nThe most similar command is\n\tremote\n",
 	})
-	if !gitResult.Fixed || gitResult.Command != "git remote '" {
-		t.Fatalf("Expected git fallback replacement, got %+v", gitResult)
+	if gitResult.Fixed {
+		t.Fatalf("Expected invalid git command to stay unchanged, got %+v", gitResult)
 	}
 
 	dockerResult := NewDockerParser().Parse(itypes.ParserContext{
 		Command: "docker psa '",
 		Stderr:  "docker: 'psa' is not a docker command.\nSimilar command: ps\n\nRun 'docker --help' for more information",
 	})
-	if !dockerResult.Fixed || dockerResult.Command != "docker ps '" {
-		t.Fatalf("Expected docker fallback replacement, got %+v", dockerResult)
+	if dockerResult.Fixed {
+		t.Fatalf("Expected invalid docker command to stay unchanged, got %+v", dockerResult)
 	}
 
 	npmResult := NewNpmParser().Parse(itypes.ParserContext{
 		Command: "npm ist '",
 		Stderr:  "npm ERR! Did you mean list?",
 	})
-	if !npmResult.Fixed || npmResult.Command != "npm list '" {
-		t.Fatalf("Expected npm fallback replacement, got %+v", npmResult)
+	if npmResult.Fixed {
+		t.Fatalf("Expected invalid npm command to stay unchanged, got %+v", npmResult)
 	}
 
 	npmNotFound := NewNpmParser().Parse(itypes.ParserContext{
 		Command: "npm isntall '",
 		Stderr:  "npm ERR! code E404\nnpm ERR! 404 command isntall not found\nnpm ERR! Did you mean install?",
 	})
-	if !npmNotFound.Fixed || npmNotFound.Command != "npm install '" {
-		t.Fatalf("Expected npm not-found fallback replacement, got %+v", npmNotFound)
+	if npmNotFound.Fixed {
+		t.Fatalf("Expected invalid npm command to stay unchanged, got %+v", npmNotFound)
 	}
 
 	dockerUnknown := NewDockerParser().Parse(itypes.ParserContext{
 		Command: "docker imagesa '",
 		Stderr:  "unknown command: imagesa\n\nDid you mean: images?",
 	})
-	if !dockerUnknown.Fixed || dockerUnknown.Command != "docker images '" {
-		t.Fatalf("Expected docker unknown-command fallback replacement, got %+v", dockerUnknown)
+	if dockerUnknown.Fixed {
+		t.Fatalf("Expected invalid docker command to stay unchanged, got %+v", dockerUnknown)
+	}
+
+	genericResult := NewGenericParser().Parse(itypes.ParserContext{
+		Command: "cargo bild 'foo   bar",
+		Stderr:  "error: no such subcommand: `bild`\n\nDid you mean `build`?",
+	})
+	if genericResult.Fixed {
+		t.Fatalf("Expected invalid generic command to stay unchanged, got %+v", genericResult)
 	}
 }
 
@@ -739,6 +772,115 @@ func TestGitParser_ParseNoUpstreamPlaceholderWithoutLocalBranch(t *testing.T) {
 	})
 	if result.Fixed {
 		t.Fatalf("Expected placeholder upstream without local branch to stay unchanged, got %+v", result)
+	}
+}
+
+func TestGitParser_ParsePushNoUpstream(t *testing.T) {
+	p := NewGitParser()
+	stderr := "fatal: The current branch feature/topic has no upstream branch.\n" +
+		"To push the current branch and set the remote as upstream, use\n\n" +
+		"    git push --set-upstream origin feature/topic\n"
+	unsafeStderr := "fatal: The current branch feature;touch${IFS}TYPO_PWNED has no upstream branch.\n" +
+		"To push the current branch and set the remote as upstream, use\n\n" +
+		"    git push --set-upstream origin feature;touch${IFS}TYPO_PWNED\n"
+
+	tests := []struct {
+		name    string
+		cmd     string
+		stderr  string
+		wantFix bool
+		wantCmd string
+	}{
+		{
+			name:    "plain push uses git hint",
+			cmd:     "git push",
+			stderr:  stderr,
+			wantFix: true,
+			wantCmd: "git push --set-upstream origin feature/topic",
+		},
+		{
+			name:    "safe push option is preserved",
+			cmd:     "git push --quiet",
+			stderr:  stderr,
+			wantFix: true,
+			wantCmd: "git push --quiet --set-upstream origin feature/topic",
+		},
+		{
+			name:    "windows CRLF hint is accepted",
+			cmd:     "git push",
+			stderr:  "fatal: The current branch feature/topic has no upstream branch.\r\nTo push the current branch and set the remote as upstream, use\r\n\r\n    git push --set-upstream origin feature/topic\r\n",
+			wantFix: true,
+			wantCmd: "git push --set-upstream origin feature/topic",
+		},
+		{
+			name:    "quoted global option is preserved",
+			cmd:     "git -C 'path with spaces' push",
+			stderr:  stderr,
+			wantFix: true,
+			wantCmd: "git -C 'path with spaces' push --set-upstream origin feature/topic",
+		},
+		{
+			name:    "git-push form is preserved",
+			cmd:     "git-push",
+			stderr:  stderr,
+			wantFix: true,
+			wantCmd: "git-push --set-upstream origin feature/topic",
+		},
+		{
+			name:    "shell metacharacters are rejected across shells",
+			cmd:     "git push",
+			stderr:  unsafeStderr,
+			wantFix: false,
+		},
+		{
+			name:    "interactive history expansion is rejected",
+			cmd:     "git push",
+			stderr:  "git push --set-upstream origin feature's!urgent\n",
+			wantFix: false,
+		},
+		{
+			name:    "hint without no upstream fatal is rejected",
+			cmd:     "git push",
+			stderr:  "git push --set-upstream origin feature/topic\n",
+			wantFix: false,
+		},
+		{
+			name: "fatal and hint branches must match",
+			cmd:  "git push",
+			stderr: "fatal: The current branch feature/topic has no upstream branch.\n" +
+				"git push --set-upstream origin other/topic\n",
+			wantFix: false,
+		},
+		{
+			name:    "existing positional argument is not duplicated",
+			cmd:     "git push origin",
+			stderr:  stderr,
+			wantFix: false,
+		},
+		{
+			name:    "existing upstream option is idempotent",
+			cmd:     "git push --set-upstream origin feature/topic",
+			stderr:  stderr,
+			wantFix: false,
+		},
+		{
+			name:    "placeholder hint is not guessed",
+			cmd:     "git push",
+			stderr:  "git push --set-upstream <remote> <branch>\n",
+			wantFix: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := p.Parse(itypes.ParserContext{Command: tt.cmd, Stderr: tt.stderr})
+			if result.Fixed != tt.wantFix {
+				t.Fatalf("Parse().Fixed = %v, want %v (%+v)", result.Fixed, tt.wantFix, result)
+			}
+			if tt.wantFix && result.Command != tt.wantCmd {
+				t.Fatalf("Parse().Command = %q, want %q", result.Command, tt.wantCmd)
+			}
+		})
 	}
 }
 
@@ -775,6 +917,11 @@ func TestGitParser_ParseDivergentPullRebase(t *testing.T) {
 			cmd:     "git-pull origin main",
 			wantFix: true,
 			wantCmd: "git-pull --rebase origin main",
+		},
+		{
+			name:    "unclosed quoted argument stays unchanged",
+			cmd:     "git pull 'foo   bar",
+			wantFix: false,
 		},
 		{
 			name:    "already has rebase",
@@ -843,7 +990,7 @@ func TestGitParser_ParseDivergentPullRebaseRequiresGitSignals(t *testing.T) {
 	}
 }
 
-func TestGitParser_ParsePushRejectedNeedsPull(t *testing.T) {
+func TestGitParser_PushRejectedDoesNotGuessPullTarget(t *testing.T) {
 	p := NewGitParser()
 	fetchFirstStderr := "To github.com:yuluo-yx/typo.git\n" +
 		" ! [rejected]        main -> main (fetch first)\n" +
@@ -852,106 +999,35 @@ func TestGitParser_ParsePushRejectedNeedsPull(t *testing.T) {
 		"hint: not have locally. This is usually caused by another repository pushing\n" +
 		"hint: to the same ref. You may want to first integrate the remote changes\n" +
 		"hint: (e.g., 'git pull ...') before pushing again.\n"
-	nonFastForwardStderr := "To github.com:yuluo-yx/typo.git\n" +
-		" ! [rejected]        main -> main (non-fast-forward)\n" +
-		"error: failed to push some refs to 'github.com:yuluo-yx/typo.git'\n" +
-		"hint: Updates were rejected because the tip of your current branch is behind\n" +
-		"hint: its remote counterpart. If you want to integrate the remote changes,\n" +
-		"hint: use 'git pull' before pushing again.\n"
 
-	tests := []struct {
-		name    string
-		cmd     string
-		stderr  string
-		wantFix bool
-		wantCmd string
-	}{
-		{
-			name:    "fetch first with remote and branch",
-			cmd:     "git push origin main",
-			stderr:  fetchFirstStderr,
-			wantFix: true,
-			wantCmd: "git pull origin main",
-		},
-		{
-			name:    "non fast forward with global option",
-			cmd:     "git -C repo push origin main",
-			stderr:  nonFastForwardStderr,
-			wantFix: true,
-			wantCmd: "git -C repo pull origin main",
-		},
-		{
-			name:    "git-push form",
-			cmd:     "git-push origin main",
-			stderr:  fetchFirstStderr,
-			wantFix: true,
-			wantCmd: "git-pull origin main",
-		},
-		{
-			name:    "push set upstream short option becomes pull long option",
-			cmd:     "git push -u origin feature",
-			stderr:  fetchFirstStderr,
-			wantFix: true,
-			wantCmd: "git pull --set-upstream origin feature",
-		},
-		{
-			name:    "push set upstream long option is preserved",
-			cmd:     "git push --set-upstream origin feature",
-			stderr:  fetchFirstStderr,
-			wantFix: true,
-			wantCmd: "git pull --set-upstream origin feature",
-		},
-		{
-			name:    "force push intent stays unchanged",
-			cmd:     "git push --force origin main",
-			stderr:  fetchFirstStderr,
-			wantFix: false,
-		},
-		{
-			name:    "push refspec stays unchanged",
-			cmd:     "git push origin HEAD:main",
-			stderr:  fetchFirstStderr,
-			wantFix: false,
-		},
-		{
-			name:    "remote policy rejection stays unchanged",
-			cmd:     "git push origin main",
-			stderr:  "To github.com:yuluo-yx/typo.git\n ! [remote rejected] main -> main (protected branch hook declined)\nerror: failed to push some refs to 'github.com:yuluo-yx/typo.git'\n",
-			wantFix: false,
-		},
-		{
-			name:    "non-push command stays unchanged",
-			cmd:     "git status",
-			stderr:  fetchFirstStderr,
-			wantFix: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := p.Parse(itypes.ParserContext{Command: tt.cmd, Stderr: tt.stderr})
-			if result.Fixed != tt.wantFix {
-				t.Fatalf("Parse().Fixed = %v, want %v (%+v)", result.Fixed, tt.wantFix, result)
-			}
-			if tt.wantFix && result.Command != tt.wantCmd {
-				t.Fatalf("Parse().Command = %q, want %q", result.Command, tt.wantCmd)
+	for _, cmd := range []string{
+		"git push",
+		"git -C 'path with spaces' push",
+		"git push origin main",
+		"git push -u origin HEAD",
+		"git push origin main other",
+	} {
+		t.Run(cmd, func(t *testing.T) {
+			result := p.Parse(itypes.ParserContext{Command: cmd, Stderr: fetchFirstStderr})
+			if result.Fixed {
+				t.Fatalf("rejected push target is ambiguous and must stay unchanged: %+v", result)
 			}
 		})
 	}
 }
 
-func TestGitParser_ParseDidYouMeanShellParseFallback(t *testing.T) {
+func TestGitParser_ParseDidYouMeanRejectsShellParseFailure(t *testing.T) {
 	stderr := "git: 'statsu' is not a git command. See 'git --help'.\n\nThe most similar command is\n\tstatus\n"
 	result := NewGitParser().Parse(itypes.ParserContext{
 		Command: "git statsu '",
 		Stderr:  stderr,
 	})
-	if !result.Fixed || result.Command != "git status '" || result.Message != "git suggested: status" {
-		t.Fatalf("Parse fallback = %+v", result)
+	if result.Fixed {
+		t.Fatalf("Expected invalid shell command to stay unchanged, got %+v", result)
 	}
 }
 
-func TestGitPullRebaseFallbackHelpers(t *testing.T) {
+func TestGitPullRebaseHelpers(t *testing.T) {
 	tests := []struct {
 		name    string
 		run     func() (string, bool)
@@ -959,20 +1035,18 @@ func TestGitPullRebaseFallbackHelpers(t *testing.T) {
 		wantOK  bool
 	}{
 		{
-			name: "plain pull parse fallback",
+			name: "plain pull malformed command",
 			run: func() (string, bool) {
 				return addGitPullRebaseFlag("git pull origin main '")
 			},
-			wantCmd: "git pull --rebase origin main '",
-			wantOK:  true,
+			wantOK: false,
 		},
 		{
-			name: "git-prefixed parse fallback",
+			name: "git-prefixed malformed command",
 			run: func() (string, bool) {
-				return addGitPrefixedPullRebaseFlag("git-pull origin main '")
+				return addGitPullRebaseFlag("git-pull origin main '")
 			},
-			wantCmd: "git-pull --rebase origin main '",
-			wantOK:  true,
+			wantOK: false,
 		},
 		{
 			name: "no pull token",
@@ -984,7 +1058,7 @@ func TestGitPullRebaseFallbackHelpers(t *testing.T) {
 		{
 			name: "empty prefixed command",
 			run: func() (string, bool) {
-				return addGitPrefixedPullRebaseFlag("")
+				return addGitPullRebaseFlag("")
 			},
 			wantOK: false,
 		},

--- a/internal/storage/files.go
+++ b/internal/storage/files.go
@@ -37,6 +37,7 @@ func (osAtomicFileOps) remove(name string) error {
 }
 
 // WriteFileAtomic writes the target file atomically by renaming a temp file in the same directory.
+// 父目录同步在 rename 提交后尽力执行，不会把已可见的写入报告为未提交。
 func WriteFileAtomic(filename string, data []byte, perm os.FileMode) error {
 	return writeFileAtomicWithOps(filename, data, perm, osAtomicFileOps{})
 }
@@ -77,9 +78,8 @@ func writeFileAtomicWithOps(filename string, data []byte, perm os.FileMode, ops 
 	}
 
 	keepTemp = true
-	if err := ops.syncDir(dir); err != nil {
-		return err
-	}
+	// rename 已经提交目标文件；目录同步只用于增强崩溃持久性，失败后无法安全回滚。
+	_ = ops.syncDir(dir)
 	return nil
 }
 

--- a/internal/storage/files.go
+++ b/internal/storage/files.go
@@ -37,7 +37,7 @@ func (osAtomicFileOps) remove(name string) error {
 }
 
 // WriteFileAtomic writes the target file atomically by renaming a temp file in the same directory.
-// 父目录同步在 rename 提交后尽力执行，不会把已可见的写入报告为未提交。
+// Parent directory sync is best-effort after rename commits, so a visible write is never reported as uncommitted.
 func WriteFileAtomic(filename string, data []byte, perm os.FileMode) error {
 	return writeFileAtomicWithOps(filename, data, perm, osAtomicFileOps{})
 }
@@ -78,7 +78,7 @@ func writeFileAtomicWithOps(filename string, data []byte, perm os.FileMode, ops 
 	}
 
 	keepTemp = true
-	// rename 已经提交目标文件；目录同步只用于增强崩溃持久性，失败后无法安全回滚。
+	// rename has already committed the target; directory sync only improves crash durability and cannot be safely rolled back.
 	_ = ops.syncDir(dir)
 	return nil
 }

--- a/internal/storage/files_test.go
+++ b/internal/storage/files_test.go
@@ -155,7 +155,7 @@ func TestWriteFileAtomic_SyncsParentDirectoryAfterRename(t *testing.T) {
 	}
 }
 
-func TestWriteFileAtomic_ParentDirectorySyncFailure(t *testing.T) {
+func TestWriteFileAtomic_ParentDirectorySyncFailureIsPostCommit(t *testing.T) {
 	target := filepath.Join(t.TempDir(), "data.json")
 	ops := &fakeAtomicFileOps{
 		file:       &fakeAtomicFile{name: "temp-file"},
@@ -163,11 +163,11 @@ func TestWriteFileAtomic_ParentDirectorySyncFailure(t *testing.T) {
 	}
 
 	err := writeFileAtomicWithOps(target, []byte("x"), 0600, ops)
-	if err == nil {
-		t.Fatal("expected WriteFileAtomic to fail when parent directory sync fails")
+	if err != nil {
+		t.Fatalf("post-rename directory sync must not report an uncommitted write: %v", err)
 	}
-	if !strings.Contains(err.Error(), "sync dir") {
-		t.Fatalf("expected parent directory sync error, got %v", err)
+	if len(ops.syncedDirs) != 1 || ops.syncedDirs[0] != filepath.Dir(target) {
+		t.Fatalf("expected parent directory sync attempt, got %v", ops.syncedDirs)
 	}
 	if len(ops.removed) != 0 {
 		t.Fatalf("expected no temp cleanup after successful rename, got %v", ops.removed)

--- a/internal/types/parser.go
+++ b/internal/types/parser.go
@@ -4,7 +4,7 @@ package types
 type ParserContext struct {
 	Command             string
 	Stderr              string
-	ExitCode            int
+	ExitCode            int // 上一条命令的退出码；-1 表示未知，0 表示成功。
 	HasMultipleCommands bool
 	HasRedirection      bool
 	HasPrivilegeWrapper bool

--- a/internal/types/parser.go
+++ b/internal/types/parser.go
@@ -4,7 +4,7 @@ package types
 type ParserContext struct {
 	Command             string
 	Stderr              string
-	ExitCode            int // 上一条命令的退出码；-1 表示未知，0 表示成功。
+	ExitCode            int // Exit code of the previous command; -1 means unknown and 0 means success.
 	HasMultipleCommands bool
 	HasRedirection      bool
 	HasPrivilegeWrapper bool


### PR DESCRIPTION
## Summary

Harden existing correction workflows so Typo only emits commands it can justify from the failed command and stderr, while keeping persisted configuration, rules, and history consistent on failures.

## Related issue

Follow-up to #192, which is already closed on `main` by `01f23a4`. This PR contains reliability findings from the subsequent project audit and does not re-close that issue.

## What changed

- Accept Git push upstream repair only from matching no-upstream fatal and concrete push hint signals, with cross-shell-safe remote and branch tokens.
- Remove ambiguous pull-upstream inference and rejected-push-to-pull conversion; reject malformed or multiply matching parser targets.
- Preserve original shell bytes during fallback correction, improve Bash/Fish integration handling, and avoid reserved file descriptor collisions.
- Validate CLI arity before storage access; surface invalid configuration; make rule, history, auto-learn, and atomic-write state transitions consistent.
- Isolate benchmark side effects, validate benchmark outputs, and update English and Chinese behavior documentation.
- Standardize source-code, Shell, workflow, and example-config comments on English while preserving Unicode test data and Chinese documentation.

## Behavioral changes

- `git pull` upstream placeholders are no longer guessed.
- Rejected `git push` commands are no longer rewritten to `git pull`.
- Malformed shell input and unsafe Git ref names remain unchanged instead of receiving a speculative correction.
- Invalid extra CLI arguments now fail without loading or mutating persistence state.

No migration is required; these behaviors directly replace unsafe or ambiguous correction paths. Revert the PR merge commit to restore the previous behavior.

## Testing performed

```text
mise exec -- make ci
mise exec -- make coverage-check
mise exec -- go vet ./...
mise exec -- go test ./internal/config ./internal/engine ./internal/storage ./internal/types -race -count=1
shellcheck --shell=bash install/typo.bash
/bin/bash -n install/typo.bash
/opt/homebrew/bin/bash -n install/typo.bash
zsh -n install/typo.zsh
fish -n install/typo.fish
pre-commit check-yaml for .github/workflows/homebrew.yml
CGO_ENABLED=0 cross-builds for linux, darwin, and windows on amd64 and arm64
mise exec -- go test ./benchmarks -run ^$ -bench ^BenchmarkTypoCLI$ -benchtime=1x -count=1
```

Results: all checks passed, `golangci-lint` reported 0 issues, `govulncheck` found no vulnerabilities, `gitleaks` found no leaks across 266 commits, total coverage is 93.2%, and the source-comment scan found no remaining Chinese comments outside documentation and Unicode test data. PowerShell host E2E and Windows-host installer tests remain skipped because `pwsh` and a Windows host are unavailable; Windows cross-builds passed.

## Checklist

- [x] I linked the related issue; #192 is already closed by the base commit.
- [x] I reviewed the testing standards and ran the relevant local checks.
- [x] I ran lint and formatting checks locally.
- [x] I updated English and Chinese documentation for user-facing behavior.
- [x] I used the required conventional commit and PR title format.
- [x] The broader file scope is one correction-reliability audit covering command safety, persistence consistency, shell integration, and their regression tests.